### PR TITLE
feat: implement Material 3 Carousel components

### DIFF
--- a/carousel/README.md
+++ b/carousel/README.md
@@ -1,0 +1,35 @@
+# Carousel
+
+Carousels display a set of items, such as images or cards, that can be scrolled horizontally.
+
+## Example Usage
+
+```html
+<script type="module">
+  import 'material/carousel/carousel.js'
+  import 'material/carousel/carousel-item.js'
+  import 'material/card/card.js'
+</script>
+
+<md-carousel>
+  <md-carousel-item>
+    <md-card>Card 1</md-card>
+  </md-carousel-item>
+  <md-carousel-item>
+    <md-card>Card 2</md-card>
+  </md-carousel-item>
+  <md-carousel-item>
+    <md-card>Card 3</md-card>
+  </md-carousel-item>
+</md-carousel>
+```
+
+## CSS Variables
+
+### `<md-carousel>`
+* `--md-carousel-gap`: Gap between carousel items (default: `8px`)
+* `--md-carousel-padding`: Padding around the carousel scroll container (default: `0`)
+
+### `<md-carousel-item>`
+* `--md-carousel-item-width`: Width of the carousel item (default: `300px`)
+* `--md-carousel-item-shape`: Border radius of the carousel item (default: `28px`)

--- a/carousel/carousel-item.js
+++ b/carousel/carousel-item.js
@@ -1,0 +1,38 @@
+import { html, LitElement, css } from 'lit'
+
+/**
+ * A Material Design carousel item component.
+ *
+ * @element md-carousel-item
+ */
+export class CarouselItem extends LitElement {
+  render() {
+    return html`
+      <div class="item-container" role="listitem">
+        <slot></slot>
+      </div>
+    `
+  }
+
+  static styles = css`
+    :host {
+      display: inline-block;
+      flex-shrink: 0;
+      scroll-snap-align: start;
+      /* default size for demo, can be overridden */
+      width: var(--md-carousel-item-width, 300px);
+    }
+
+    .item-container {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      box-sizing: border-box;
+      /* Usually border radius of 28px or 24px in MD3 depending on variant */
+      border-radius: var(--md-carousel-item-shape, 28px);
+      overflow: hidden;
+    }
+  `
+}
+
+customElements.define('md-carousel-item', CarouselItem)

--- a/carousel/carousel.js
+++ b/carousel/carousel.js
@@ -1,0 +1,53 @@
+import { html, LitElement, css } from 'lit'
+
+/**
+ * A Material Design carousel component.
+ *
+ * @element md-carousel
+ */
+export class Carousel extends LitElement {
+  static properties = {
+    ariaLabel: { type: String, attribute: 'aria-label' },
+  }
+
+  constructor() {
+    super()
+    this.ariaLabel = 'Carousel'
+  }
+
+  render() {
+    return html`
+      <div class="scroll-container" role="list" aria-label="${this.ariaLabel}">
+        <slot></slot>
+      </div>
+    `
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+      /* Carousel styling based on Material Design 3 */
+      /* Note: specific width/height may need to be configurable */
+    }
+
+    .scroll-container {
+      display: flex;
+      gap: var(--md-carousel-gap, 8px);
+      overflow-x: auto;
+      scroll-snap-type: x mandatory;
+      overscroll-behavior-x: contain;
+
+      /* Hide scrollbar for cleaner look, but keep functionality */
+      scrollbar-width: none; /* Firefox */
+      -ms-overflow-style: none; /* IE and Edge */
+
+      padding: var(--md-carousel-padding, 0);
+    }
+
+    .scroll-container::-webkit-scrollbar {
+      display: none; /* Chrome, Safari and Opera */
+    }
+  `
+}
+
+customElements.define('md-carousel', Carousel)

--- a/demo/index.html
+++ b/demo/index.html
@@ -58,6 +58,9 @@
       import 'material/snackbar/snackbar.js'
       import 'material/app/bar.js'
       import 'material/progress/progress.js'
+      import 'material/carousel/carousel.js'
+      import 'material/carousel/carousel-item.js'
+      import 'material/card/card.js'
       import './components/expressive-component.js'
     </script>
 
@@ -178,7 +181,36 @@
               <expressive-component></expressive-component>
             </div>
 
-            <h3>Progress</h3>
+
+            <h3>Carousel</h3>
+            <md-carousel style="margin-bottom: 24px;">
+              <md-carousel-item>
+                <md-card style="height: 200px; display: flex; align-items: center; justify-content: center; background-color: var(--md-sys-color-primary-container); color: var(--md-sys-color-on-primary-container);">
+                  <div style="padding: 24px;">Item 1</div>
+                </md-card>
+              </md-carousel-item>
+              <md-carousel-item>
+                <md-card style="height: 200px; display: flex; align-items: center; justify-content: center; background-color: var(--md-sys-color-secondary-container); color: var(--md-sys-color-on-secondary-container);">
+                  <div style="padding: 24px;">Item 2</div>
+                </md-card>
+              </md-carousel-item>
+              <md-carousel-item>
+                <md-card style="height: 200px; display: flex; align-items: center; justify-content: center; background-color: var(--md-sys-color-tertiary-container); color: var(--md-sys-color-on-tertiary-container);">
+                  <div style="padding: 24px;">Item 3</div>
+                </md-card>
+              </md-carousel-item>
+              <md-carousel-item>
+                <md-card style="height: 200px; display: flex; align-items: center; justify-content: center; background-color: var(--md-sys-color-error-container); color: var(--md-sys-color-on-error-container);">
+                  <div style="padding: 24px;">Item 4</div>
+                </md-card>
+              </md-carousel-item>
+              <md-carousel-item>
+                <md-card style="height: 200px; display: flex; align-items: center; justify-content: center; background-color: var(--md-sys-color-surface-variant); color: var(--md-sys-color-on-surface-variant);">
+                  <div style="padding: 24px;">Item 5</div>
+                </md-card>
+              </md-carousel-item>
+            </md-carousel>
+<h3>Progress</h3>
             <md-progress type="circular" indeterminate></md-progress>
             <md-progress type="linear" value="0.5" indeterminate></md-progress>
 


### PR DESCRIPTION
Implemented Material Design 3 carousel components.

Includes `md-carousel` and `md-carousel-item` written as Lit elements leveraging modern CSS capabilities like flexbox and scroll snapping to achieve native-feeling interactions. Tested visually via Playwright.

Components:
- `md-carousel`: The horizontal scroll container (`role="list"`).
- `md-carousel-item`: The individual snap targets (`role="listitem"`).

Added demo showcasing usage with `md-card` and documented customizable CSS variables in a new `README.md`.

---
*PR created automatically by Jules for task [8823521121697351188](https://jules.google.com/task/8823521121697351188) started by @treeder*