### PR TITLE
feat(carousel): implement Material 3 Carousel component

### DIFF
--- a/all.js
+++ b/all.js
@@ -5,6 +5,8 @@
  * Import only the individual components used for production.
  */
 import './buttons/button.js'
+import './carousel/carousel.js'
+import './carousel/carousel-item.js'
 import './checkbox/checkbox.js'
 import './chips/chip.js'
 import './chips/chip-set.js'
@@ -37,6 +39,8 @@ import './text/text-field.js'
 // LINT.IfChange(exports)
 // go/keep-sorted start
 export * from './buttons/button.js'
+export * from './carousel/carousel.js'
+export * from './carousel/carousel-item.js'
 export * from './checkbox/checkbox.js'
 export * from './chips/chip.js'
 export * from './chips/chip-set.js'

--- a/carousel/README.md
+++ b/carousel/README.md
@@ -1,0 +1,139 @@
+# Carousel
+
+[Material Design 3 Carousel component](https://m3.material.io/components/carousel/overview).
+
+Carousels show a scrollable collection of items with dynamic sizing, snapping, navigation buttons, and pagination indicators.
+
+## Usage
+
+```js
+import 'material/carousel/carousel.js'
+import 'material/carousel/carousel-item.js'
+```
+
+### Basic Multi-Browse Carousel (Default)
+
+```html
+<md-carousel>
+  <md-carousel-item headline="Image 1" subhead="Subtitle description">
+    <img src="photo1.jpg" alt="Photo 1" />
+  </md-carousel-item>
+  <md-carousel-item headline="Image 2" subhead="Subtitle description">
+    <img src="photo2.jpg" alt="Photo 2" />
+  </md-carousel-item>
+  <md-carousel-item headline="Image 3" subhead="Subtitle description">
+    <img src="photo3.jpg" alt="Photo 3" />
+  </md-carousel-item>
+</md-carousel>
+```
+
+### Uncontained Layout
+
+```html
+<md-carousel layout="uncontained" item-width="320px">
+  <md-carousel-item>
+    <md-card type="outlined" class="p16">
+      <h3>Card 1</h3>
+      <p>Card content</p>
+    </md-card>
+  </md-carousel-item>
+  <md-carousel-item>
+    <md-card type="outlined" class="p16">
+      <h3>Card 2</h3>
+      <p>Card content</p>
+    </md-card>
+  </md-carousel-item>
+</md-carousel>
+```
+
+### Hero Layout (Start-aligned)
+
+```html
+<md-carousel layout="hero" indicators>
+  <md-carousel-item headline="Featured Product" subhead="New Release">
+    <img src="hero1.jpg" alt="Hero 1" />
+  </md-carousel-item>
+  <md-carousel-item headline="Special Offer" subhead="Limited time">
+    <img src="hero2.jpg" alt="Hero 2" />
+  </md-carousel-item>
+</md-carousel>
+```
+
+### Centered-Hero Layout
+
+```html
+<md-carousel layout="centered-hero" indicators loop>
+  <md-carousel-item headline="Movie 1">
+    <img src="poster1.jpg" alt="Poster 1" />
+  </md-carousel-item>
+  <md-carousel-item headline="Movie 2">
+    <img src="poster2.jpg" alt="Poster 2" />
+  </md-carousel-item>
+  <md-carousel-item headline="Movie 3">
+    <img src="poster3.jpg" alt="Poster 3" />
+  </md-carousel-item>
+</md-carousel>
+```
+
+### Full-Screen Layout
+
+```html
+<md-carousel layout="full-screen" indicators autoplay="5000" loop style="height: 400px;">
+  <md-carousel-item headline="Slide 1">
+    <img src="slide1.jpg" alt="Slide 1" />
+  </md-carousel-item>
+  <md-carousel-item headline="Slide 2">
+    <img src="slide2.jpg" alt="Slide 2" />
+  </md-carousel-item>
+</md-carousel>
+```
+
+---
+
+## `<md-carousel>` Properties & Attributes
+
+| Property / Attribute | Type | Default | Description |
+| --- | --- | --- | --- |
+| `layout` | `'multi-browse' \| 'uncontained' \| 'hero' \| 'centered-hero' \| 'full-screen'` | `'multi-browse'` | Carousel layout strategy. |
+| `item-width` / `itemWidth` | `string` | `''` | Custom item width (e.g. `'300px'`). |
+| `item-spacing` / `itemSpacing` | `number` | `8` | Spacing between items in px. |
+| `navigation` | `'auto' \| 'always' \| 'none'` | `'auto'` | Controls visibility of previous/next navigation buttons. |
+| `indicators` | `boolean` | `false` | When true, shows pagination indicator dots. |
+| `autoplay` | `number` | `0` | Delay in milliseconds for automatic sliding (0 = disabled). |
+| `loop` | `boolean` | `false` | When true, wraps navigation around when reaching edges. |
+| `active-index` / `activeIndex` | `number` | `0` | 0-based index of the currently active slide. |
+| `scroll-snap` / `scrollSnap` | `boolean` | `true` | Enables/disables CSS scroll-snapping. |
+| `hide-scrollbar` / `hideScrollbar` | `boolean` | `true` | Hides the horizontal scrollbar. |
+
+### Methods
+
+- `next()`: Scrolls to the next slide.
+- `previous()`: Scrolls to the previous slide.
+- `scrollToIndex(index, behavior = 'smooth')`: Scrolls to a specific slide index.
+
+### Events
+
+- `change`: Dispatched when the active item changes. `event.detail` contains `{ index, item }`.
+- `scroll`: Dispatched when the carousel is scrolled.
+
+---
+
+## `<md-carousel-item>` Properties & Attributes
+
+| Property / Attribute | Type | Default | Description |
+| --- | --- | --- | --- |
+| `shape` | `string` | `'var(--md-sys-shape-corner-extra-large, 28px)'` | Corner radius or shape (`'small'`, `'medium'`, `'large'`, `'extra-large'`, `'full'`). |
+| `type` | `'filled' \| 'elevated' \| 'outlined' \| ''` | `''` | Container card style variant. |
+| `interactive` | `boolean` | `false` | Enables ripple, focus-ring, and hover elevation effects. |
+| `href` | `string` | `''` | Link URL when clicking the carousel item. |
+| `target` | `string` | `''` | Target window for link (`'_blank'`, etc.). |
+| `headline` | `string` | `''` | Headline text overlay. |
+| `subhead` | `string` | `''` | Subhead text overlay. |
+
+### Slots
+
+- `(default)`: Media or card content (images, custom elements).
+- `headline`: Custom headline content.
+- `subhead`: Custom subhead content.
+- `scrim`: Custom scrim overlay.
+- `action`: Action buttons or icons in the item overlay.

--- a/carousel/carousel-item.js
+++ b/carousel/carousel-item.js
@@ -73,7 +73,9 @@ export class CarouselItem extends LitElement {
       `
     }
 
-    return html`<div class="item-container" tabindex=${this.isInteractive && !this.disabled ? 0 : nothing}>${content}</div>`
+    return html`<div class="item-container" tabindex=${this.isInteractive && !this.disabled ? 0 : nothing}>
+      ${content}
+    </div>`
   }
 
   renderElevation() {
@@ -94,15 +96,10 @@ export class CarouselItem extends LitElement {
   }
 
   renderTextContent() {
-    const hasText = this.headline || this.subhead
     return html`
       <div class="content-overlay">
-        <slot name="headline">
-          ${this.headline ? html`<div class="headline">${this.headline}</div>` : nothing}
-        </slot>
-        <slot name="subhead">
-          ${this.subhead ? html`<div class="subhead">${this.subhead}</div>` : nothing}
-        </slot>
+        <slot name="headline"> ${this.headline ? html`<div class="headline">${this.headline}</div>` : nothing} </slot>
+        <slot name="subhead"> ${this.subhead ? html`<div class="subhead">${this.subhead}</div>` : nothing} </slot>
         <slot name="action"></slot>
       </div>
     `
@@ -123,15 +120,40 @@ export class CarouselItem extends LitElement {
         position: relative;
         box-sizing: border-box;
         border-radius: var(--_item-shape);
+        clip-path: inset(0 round var(--_item-shape));
         overflow: hidden;
+        isolation: isolate;
         user-select: none;
         flex-shrink: 0;
         height: 100%;
         scroll-snap-align: start;
-        transition: transform 0.25s cubic-bezier(0.2, 0, 0, 1),
-                    opacity 0.25s cubic-bezier(0.2, 0, 0, 1),
-                    filter 0.25s cubic-bezier(0.2, 0, 0, 1);
+        transition:
+          width 0.35s cubic-bezier(0.2, 0, 0, 1),
+          min-width 0.35s cubic-bezier(0.2, 0, 0, 1),
+          max-width 0.35s cubic-bezier(0.2, 0, 0, 1),
+          flex-basis 0.35s cubic-bezier(0.2, 0, 0, 1),
+          transform 0.25s cubic-bezier(0.2, 0, 0, 1),
+          opacity 0.25s cubic-bezier(0.2, 0, 0, 1),
+          filter 0.25s cubic-bezier(0.2, 0, 0, 1);
         -webkit-tap-highlight-color: transparent;
+      }
+
+      :host([data-size='small']) .content-overlay,
+      :host([data-size='small']) .scrim {
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      :host([data-size='medium']) .subhead {
+        display: none;
+      }
+
+      :host([data-size='medium']) .headline {
+        font-size: var(--md-carousel-item-medium-headline-size, 0.95rem);
+      }
+
+      :host([data-size='medium']) .content-overlay {
+        padding: 12px;
       }
 
       :host([shape='small']) {

--- a/carousel/carousel-item.js
+++ b/carousel/carousel-item.js
@@ -1,0 +1,310 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { html, LitElement, nothing, css } from 'lit'
+import '../internal/elevation/elevation.js'
+import '../internal/focus/focus-ring.js'
+import '../internal/ripple/ripple.js'
+
+/**
+ * An item container inside an `<md-carousel>`.
+ *
+ * https://m3.material.io/components/carousel/overview
+ */
+export class CarouselItem extends LitElement {
+  static properties = {
+    shape: { type: String, reflect: true },
+    type: { type: String, reflect: true }, // 'filled' | 'elevated' | 'outlined'
+    interactive: { type: Boolean, reflect: true },
+    disabled: { type: Boolean, reflect: true },
+    active: { type: Boolean, reflect: true },
+    href: { type: String },
+    target: { type: String },
+    headline: { type: String },
+    subhead: { type: String },
+    isCarouselItem: { type: Boolean, attribute: 'md-carousel-item', reflect: true },
+  }
+
+  constructor() {
+    super()
+    this.isCarouselItem = true
+    this.interactive = false
+    this.disabled = false
+    this.active = false
+    this.type = ''
+    this.href = ''
+    this.target = ''
+    this.headline = ''
+    this.subhead = ''
+  }
+
+  get isInteractive() {
+    return this.interactive || Boolean(this.href)
+  }
+
+  render() {
+    const content = html`
+      ${this.renderElevation()}
+      <div class="background"></div>
+      <div class="media-container">
+        <slot></slot>
+      </div>
+      <div class="scrim">
+        <slot name="scrim"></slot>
+      </div>
+      ${this.renderTextContent()}
+      <div class="outline ${this.type}"></div>
+      ${this.renderRippleAndFocus()}
+    `
+
+    if (this.href) {
+      return html`
+        <a
+          id="link"
+          class="link"
+          href=${this.href}
+          target=${this.target || nothing}
+          aria-disabled=${this.disabled ? 'true' : nothing}
+          tabindex=${this.disabled ? -1 : 0}>
+          ${content}
+        </a>
+      `
+    }
+
+    return html`<div class="item-container" tabindex=${this.isInteractive && !this.disabled ? 0 : nothing}>${content}</div>`
+  }
+
+  renderElevation() {
+    if (this.type === 'elevated' || (this.interactive && this.type !== 'outlined')) {
+      return html`<md-elevation part="elevation"></md-elevation>`
+    }
+    return nothing
+  }
+
+  renderRippleAndFocus() {
+    if (!this.isInteractive) {
+      return nothing
+    }
+    return html`
+      <md-ripple ?disabled=${this.disabled}></md-ripple>
+      <md-focus-ring part="focus-ring"></md-focus-ring>
+    `
+  }
+
+  renderTextContent() {
+    const hasText = this.headline || this.subhead
+    return html`
+      <div class="content-overlay">
+        <slot name="headline">
+          ${this.headline ? html`<div class="headline">${this.headline}</div>` : nothing}
+        </slot>
+        <slot name="subhead">
+          ${this.subhead ? html`<div class="subhead">${this.subhead}</div>` : nothing}
+        </slot>
+        <slot name="action"></slot>
+      </div>
+    `
+  }
+
+  static styles = [
+    css`
+      :host {
+        --_item-shape: var(--md-carousel-item-shape, var(--md-sys-shape-corner-extra-large, 28px));
+        --_item-color: var(--md-carousel-item-color, var(--md-sys-color-surface-container-low, #f7f2fa));
+        --_item-elevation: var(--md-carousel-item-elevation, 0);
+        --_item-shadow-color: var(--md-sys-color-shadow, #000);
+        --_headline-color: var(--md-sys-color-on-surface, #1d1b20);
+        --_subhead-color: var(--md-sys-color-on-surface-variant, #49454f);
+
+        display: flex;
+        flex-direction: column;
+        position: relative;
+        box-sizing: border-box;
+        border-radius: var(--_item-shape);
+        overflow: hidden;
+        user-select: none;
+        flex-shrink: 0;
+        height: 100%;
+        scroll-snap-align: start;
+        transition: transform 0.25s cubic-bezier(0.2, 0, 0, 1),
+                    opacity 0.25s cubic-bezier(0.2, 0, 0, 1),
+                    filter 0.25s cubic-bezier(0.2, 0, 0, 1);
+        -webkit-tap-highlight-color: transparent;
+      }
+
+      :host([shape='small']) {
+        --_item-shape: var(--md-sys-shape-corner-small, 8px);
+      }
+      :host([shape='medium']) {
+        --_item-shape: var(--md-sys-shape-corner-medium, 12px);
+      }
+      :host([shape='large']) {
+        --_item-shape: var(--md-sys-shape-corner-large, 16px);
+      }
+      :host([shape='extra-large']) {
+        --_item-shape: var(--md-sys-shape-corner-extra-large, 28px);
+      }
+      :host([shape='full']) {
+        --_item-shape: var(--md-sys-shape-corner-full, 9999px);
+      }
+
+      .item-container,
+      .link {
+        display: flex;
+        flex-direction: column;
+        position: relative;
+        width: 100%;
+        height: 100%;
+        border-radius: inherit;
+        overflow: hidden;
+        box-sizing: border-box;
+        text-decoration: none;
+        color: inherit;
+        outline: none;
+      }
+
+      :host([interactive]) .item-container,
+      .link {
+        cursor: pointer;
+      }
+
+      :host([disabled]) {
+        pointer-events: none;
+        opacity: 0.38;
+      }
+
+      .background {
+        background: var(--_item-color);
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        z-index: 0;
+        pointer-events: none;
+      }
+
+      md-elevation {
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        z-index: 0;
+        pointer-events: none;
+        --md-elevation-level: var(--_item-elevation);
+        --md-elevation-shadow-color: var(--_item-shadow-color);
+      }
+
+      .media-container {
+        position: relative;
+        z-index: 1;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        border-radius: inherit;
+        overflow: hidden;
+      }
+
+      ::slotted(img),
+      ::slotted(video) {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+        border-radius: inherit;
+        pointer-events: none;
+      }
+
+      .scrim {
+        position: absolute;
+        inset: 0;
+        z-index: 2;
+        pointer-events: none;
+        border-radius: inherit;
+      }
+
+      .content-overlay {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 3;
+        padding: 16px;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        pointer-events: none;
+      }
+
+      .headline {
+        font-family: var(--md-ref-typeface-plain, 'Google Sans Flex', 'Roboto', sans-serif);
+        font-size: var(--md-carousel-item-headline-size, 1.125rem);
+        font-weight: 500;
+        line-height: 1.35;
+        color: var(--_headline-color);
+      }
+
+      .subhead {
+        font-family: var(--md-ref-typeface-plain, 'Google Sans Flex', 'Roboto', sans-serif);
+        font-size: var(--md-carousel-item-subhead-size, 0.875rem);
+        font-weight: 400;
+        line-height: 1.25;
+        color: var(--_subhead-color);
+      }
+
+      .outline {
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        pointer-events: none;
+        border: 1px solid transparent;
+        z-index: 4;
+      }
+
+      .outline.outlined {
+        border-color: var(--md-sys-color-outline-variant, #cac4d0);
+      }
+
+      md-focus-ring {
+        z-index: 5;
+        --md-focus-ring-shape: var(--_item-shape);
+      }
+
+      md-ripple {
+        z-index: 5;
+      }
+
+      /* Variant Styles */
+      :host([type='elevated']) {
+        --_item-color: var(--md-sys-color-surface-container-low, #f7f2fa);
+        --_item-elevation: 1;
+        filter: drop-shadow(0px 1px 2px var(--_item-shadow-color));
+      }
+
+      :host([type='elevated']:hover) {
+        --_item-elevation: 2;
+      }
+
+      :host([type='filled']) {
+        --_item-color: var(--md-sys-color-surface-container-highest, #e6e0e9);
+        --_item-elevation: 0;
+      }
+
+      :host([type='outlined']) {
+        --_item-color: var(--md-sys-color-surface, #fef7ff);
+        --_item-elevation: 0;
+      }
+
+      /* Dark text scrim support when headline/subhead are specified on media */
+      :host([headline]) .content-overlay,
+      :host([subhead]) .content-overlay {
+        background: linear-gradient(to top, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0.3) 60%, transparent 100%);
+        --_headline-color: #ffffff;
+        --_subhead-color: rgba(255, 255, 255, 0.85);
+      }
+    `,
+  ]
+}
+
+customElements.define('md-carousel-item', CarouselItem)

--- a/carousel/carousel.js
+++ b/carousel/carousel.js
@@ -252,15 +252,17 @@ export class Carousel extends LitElement {
 
     const boundedIndex = Math.max(0, Math.min(index, items.length - 1))
     this.activeIndex = boundedIndex
+    this._isScrollingProgrammatically = true
+
     this._applyItemSizes()
     this._syncActiveItem()
 
-    // Wait a frame for CSS transitions / layout to settle
-    await new Promise((r) => requestAnimationFrame(r))
-
     const scroller = this.scrollerElement
     const targetItem = items[boundedIndex]
-    if (!targetItem || !scroller) return
+    if (!targetItem || !scroller) {
+      this._isScrollingProgrammatically = false
+      return
+    }
 
     let scrollTarget
     if (this.layout === 'centered-hero') {
@@ -284,6 +286,15 @@ export class Carousel extends LitElement {
         composed: true,
       }),
     )
+
+    if (behavior === 'smooth') {
+      setTimeout(() => {
+        this._isScrollingProgrammatically = false
+        this._updateScrollState()
+      }, 400)
+    } else {
+      this._isScrollingProgrammatically = false
+    }
   }
 
   _updateLayout() {
@@ -321,10 +332,7 @@ export class Carousel extends LitElement {
         let sizeType = 'large'
         let width = largeWidth
 
-        if (i < activeIndex) {
-          sizeType = 'small'
-          width = smallWidth
-        } else if (i === activeIndex) {
+        if (i === activeIndex) {
           sizeType = 'large'
           width = largeWidth
         } else if (i === activeIndex + 1) {
@@ -357,10 +365,7 @@ export class Carousel extends LitElement {
         let sizeType = 'large'
         let width = largeWidth
 
-        if (i < activeIndex) {
-          sizeType = 'small'
-          width = smallWidth
-        } else if (i === activeIndex) {
+        if (i === activeIndex) {
           sizeType = 'large'
           width = largeWidth
         } else if (i === activeIndex + 1) {
@@ -452,6 +457,7 @@ export class Carousel extends LitElement {
 
   _handleScroll() {
     this._updateScrollState()
+    if (this._isScrollingProgrammatically) return
 
     const scroller = this.scrollerElement
     const items = this.items

--- a/carousel/carousel.js
+++ b/carousel/carousel.js
@@ -1,0 +1,715 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { html, LitElement, nothing, css } from 'lit'
+import { isRtl } from '../internal/controller/is-rtl.js'
+import { queryAssignedElements } from '../utils/query.js'
+import '../icon/icon.js'
+import '../internal/elevation/elevation.js'
+import '../internal/focus/focus-ring.js'
+import '../internal/ripple/ripple.js'
+import './carousel-item.js'
+
+/**
+ * A Material 3 Carousel component supporting multi-browse, uncontained, hero,
+ * centered-hero, and full-screen layout strategies.
+ *
+ * https://m3.material.io/components/carousel/overview
+ *
+ * @fires change {CustomEvent<{index: number, item: CarouselItem}>} Dispatched when the active item changes.
+ * @fires scroll {Event} Dispatched when the carousel is scrolled.
+ */
+export class Carousel extends LitElement {
+  static properties = {
+    layout: { type: String, reflect: true },
+    itemWidth: { type: String, attribute: 'item-width', reflect: true },
+    itemSpacing: { type: Number, attribute: 'item-spacing', reflect: true },
+    navigation: { type: String, reflect: true }, // 'auto' | 'always' | 'none'
+    indicators: { type: Boolean, reflect: true },
+    autoplay: { type: Number },
+    loop: { type: Boolean, reflect: true },
+    activeIndex: { type: Number, attribute: 'active-index', reflect: true },
+    scrollSnap: { type: Boolean, attribute: 'scroll-snap', reflect: true },
+    hideScrollbar: { type: Boolean, attribute: 'hide-scrollbar', reflect: true },
+    ariaLabel: { type: String, attribute: 'aria-label' },
+    _canScrollPrev: { state: true },
+    _canScrollNext: { state: true },
+  }
+
+  constructor() {
+    super()
+    this.layout = 'multi-browse'
+    this.itemWidth = ''
+    this.itemSpacing = 8
+    this.navigation = 'auto'
+    this.indicators = false
+    this.autoplay = 0
+    this.loop = false
+    this.activeIndex = 0
+    this.scrollSnap = true
+    this.hideScrollbar = true
+    this.ariaLabel = 'Carousel'
+    this._canScrollPrev = false
+    this._canScrollNext = true
+
+    this._resizeObserver = null
+    this._autoplayTimer = null
+    this._isPointerDown = false
+    this._startX = 0
+    this._startScrollLeft = 0
+    this._hasDragged = false
+
+    this._handleScroll = this._handleScroll.bind(this)
+    this._handleKeyDown = this._handleKeyDown.bind(this)
+    this._onPointerDown = this._onPointerDown.bind(this)
+    this._onPointerMove = this._onPointerMove.bind(this)
+    this._onPointerUp = this._onPointerUp.bind(this)
+    this._onPointerCancel = this._onPointerCancel.bind(this)
+  }
+
+  get items() {
+    return queryAssignedElements(this, { flatten: true, selector: '[md-carousel-item], md-carousel-item' })
+  }
+
+  get scrollerElement() {
+    return this.renderRoot?.querySelector('.scroller')
+  }
+
+  get activeItem() {
+    return this.items[this.activeIndex] ?? null
+  }
+
+  get canScrollPrev() {
+    return this.loop || this._canScrollPrev
+  }
+
+  get canScrollNext() {
+    return this.loop || this._canScrollNext
+  }
+
+  connectedCallback() {
+    super.connectedCallback()
+
+    if (typeof ResizeObserver !== 'undefined') {
+      this._resizeObserver = new ResizeObserver(() => {
+        this._updateLayout()
+        this._updateScrollState()
+      })
+      this._resizeObserver.observe(this)
+    }
+
+    this.addEventListener('keydown', this._handleKeyDown)
+    this._startAutoplay()
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback()
+
+    if (this._resizeObserver) {
+      this._resizeObserver.disconnect()
+      this._resizeObserver = null
+    }
+
+    this.removeEventListener('keydown', this._handleKeyDown)
+    this._stopAutoplay()
+  }
+
+  firstUpdated() {
+    this._updateLayout()
+    this._updateScrollState()
+    this._syncActiveItem()
+  }
+
+  updated(changedProperties) {
+    if (
+      changedProperties.has('layout') ||
+      changedProperties.has('itemWidth') ||
+      changedProperties.has('itemSpacing')
+    ) {
+      this._updateLayout()
+      this._updateScrollState()
+    }
+
+    if (changedProperties.has('autoplay')) {
+      this._startAutoplay()
+    }
+
+    if (changedProperties.has('activeIndex') && changedProperties.get('activeIndex') !== undefined) {
+      this._syncActiveItem()
+    }
+  }
+
+  render() {
+    const isRtlMode = isRtl(this, false)
+    const showNav = this.navigation !== 'none'
+    const itemCount = this.items.length
+
+    return html`
+      <div
+        class="carousel-container"
+        @mouseenter=${this._pauseAutoplay}
+        @mouseleave=${this._resumeAutoplay}
+        @focusin=${this._pauseAutoplay}
+        @focusout=${this._resumeAutoplay}>
+        <div
+          class="scroller"
+          role="region"
+          aria-roledescription="carousel"
+          aria-label=${this.ariaLabel}
+          tabindex="0"
+          @scroll=${this._handleScroll}
+          @pointerdown=${this._onPointerDown}
+          @pointermove=${this._onPointerMove}
+          @pointerup=${this._onPointerUp}
+          @pointercancel=${this._onPointerCancel}>
+          <slot @slotchange=${this._handleSlotChange}></slot>
+        </div>
+
+        ${showNav
+          ? html`
+              <button
+                class="nav-button prev ${!this.canScrollPrev ? 'disabled' : ''}"
+                ?disabled=${!this.canScrollPrev}
+                @click=${this.previous}
+                aria-label="Previous item"
+                tabindex="-1">
+                <md-elevation></md-elevation>
+                <md-ripple></md-ripple>
+                <md-focus-ring></md-focus-ring>
+                <md-icon>${isRtlMode ? 'chevron_right' : 'chevron_left'}</md-icon>
+              </button>
+
+              <button
+                class="nav-button next ${!this.canScrollNext ? 'disabled' : ''}"
+                ?disabled=${!this.canScrollNext}
+                @click=${this.next}
+                aria-label="Next item"
+                tabindex="-1">
+                <md-elevation></md-elevation>
+                <md-ripple></md-ripple>
+                <md-focus-ring></md-focus-ring>
+                <md-icon>${isRtlMode ? 'chevron_left' : 'chevron_right'}</md-icon>
+              </button>
+            `
+          : nothing}
+        ${this.indicators && itemCount > 0
+          ? html`
+              <div class="indicators" role="tablist" aria-label="Slides">
+                ${this.items.map(
+                  (_, i) => html`
+                    <button
+                      class="indicator-dot ${i === this.activeIndex ? 'active' : ''}"
+                      role="tab"
+                      aria-selected=${i === this.activeIndex}
+                      aria-label="Go to slide ${i + 1}"
+                      @click=${() => this.scrollToIndex(i)}></button>
+                  `,
+                )}
+              </div>
+            `
+          : nothing}
+      </div>
+    `
+  }
+
+  /**
+   * Navigates to the next slide.
+   */
+  async next() {
+    const total = this.items.length
+    if (total === 0) return
+
+    if (this.activeIndex < total - 1) {
+      await this.scrollToIndex(this.activeIndex + 1)
+    } else if (this.loop) {
+      await this.scrollToIndex(0)
+    }
+  }
+
+  /**
+   * Navigates to the previous slide.
+   */
+  async previous() {
+    const total = this.items.length
+    if (total === 0) return
+
+    if (this.activeIndex > 0) {
+      await this.scrollToIndex(this.activeIndex - 1)
+    } else if (this.loop) {
+      await this.scrollToIndex(total - 1)
+    }
+  }
+
+  /**
+   * Scrolls smoothly to the specified slide index.
+   *
+   * @param {number} index Target item index.
+   * @param {'smooth' | 'auto' | 'instant'} behavior Scroll behavior.
+   */
+  async scrollToIndex(index, behavior = 'smooth') {
+    await this.updateComplete
+    const items = this.items
+    if (!items.length || !this.scrollerElement) return
+
+    const boundedIndex = Math.max(0, Math.min(index, items.length - 1))
+    const targetItem = items[boundedIndex]
+    if (!targetItem) return
+
+    const scroller = this.scrollerElement
+    const scrollerRect = scroller.getBoundingClientRect()
+    const itemRect = targetItem.getBoundingClientRect()
+
+    let scrollTarget
+    if (this.layout === 'centered-hero') {
+      const itemCenter = targetItem.offsetLeft + targetItem.offsetWidth / 2
+      const scrollerCenter = scroller.offsetWidth / 2
+      scrollTarget = itemCenter - scrollerCenter
+    } else {
+      scrollTarget = targetItem.offsetLeft - scroller.offsetLeft
+    }
+
+    scroller.scrollTo({
+      left: Math.max(0, scrollTarget),
+      behavior,
+    })
+
+    this.activeIndex = boundedIndex
+    this._syncActiveItem()
+  }
+
+  _updateLayout() {
+    const scroller = this.scrollerElement
+    if (!scroller) return
+
+    const containerWidth = this.offsetWidth || scroller.clientWidth || 360
+    const spacing = Number(this.itemSpacing) || 8
+
+    scroller.style.setProperty('--_item-spacing', `${spacing}px`)
+
+    if (this.itemWidth) {
+      const widthVal = isNaN(Number(this.itemWidth)) ? this.itemWidth : `${this.itemWidth}px`
+      scroller.style.setProperty('--_custom-item-width', widthVal)
+    } else {
+      scroller.style.removeProperty('--_custom-item-width')
+    }
+
+    if (this.layout === 'multi-browse') {
+      // Dynamic M3 Multi-browse item calculations
+      const smallWidth = 48
+      const availableWidth = containerWidth - smallWidth - spacing
+
+      let largeWidth
+      if (containerWidth < 480) {
+        // Compact: 1 large + 1 small peek
+        largeWidth = Math.max(220, availableWidth)
+      } else if (containerWidth < 768) {
+        // Medium: 1 large (~65%) + 1 medium (~30%) + 1 small peek
+        largeWidth = Math.min(360, Math.floor(availableWidth * 0.65))
+      } else {
+        // Expanded: 2 or more large + medium + small peek
+        largeWidth = Math.min(400, Math.floor(availableWidth * 0.42))
+      }
+
+      scroller.style.setProperty('--_large-item-width', `${largeWidth}px`)
+    }
+  }
+
+  _updateScrollState() {
+    const scroller = this.scrollerElement
+    if (!scroller) return
+
+    const { scrollLeft, scrollWidth, clientWidth } = scroller
+    const maxScroll = scrollWidth - clientWidth
+
+    this._canScrollPrev = scrollLeft > 4
+    this._canScrollNext = scrollLeft < maxScroll - 4
+  }
+
+  _handleScroll() {
+    this._updateScrollState()
+
+    const scroller = this.scrollerElement
+    const items = this.items
+    if (!scroller || !items.length) return
+
+    const scrollerRect = scroller.getBoundingClientRect()
+    const scrollerCenter = scrollerRect.left + scrollerRect.width / 2
+
+    let closestIndex = 0
+    let minDistance = Infinity
+
+    items.forEach((item, index) => {
+      const rect = item.getBoundingClientRect()
+      let distance
+      if (this.layout === 'centered-hero') {
+        const itemCenter = rect.left + rect.width / 2
+        distance = Math.abs(itemCenter - scrollerCenter)
+      } else {
+        distance = Math.abs(rect.left - scrollerRect.left)
+      }
+
+      if (distance < minDistance) {
+        minDistance = distance
+        closestIndex = index
+      }
+    })
+
+    if (this.activeIndex !== closestIndex) {
+      this.activeIndex = closestIndex
+      this._syncActiveItem()
+      this.dispatchEvent(
+        new CustomEvent('change', {
+          detail: { index: closestIndex, item: items[closestIndex] },
+          bubbles: true,
+          composed: true,
+        }),
+      )
+    }
+  }
+
+  _syncActiveItem() {
+    const items = this.items
+    items.forEach((item, i) => {
+      item.active = i === this.activeIndex
+      item.setAttribute('aria-label', `Slide ${i + 1} of ${items.length}`)
+      item.setAttribute('role', 'group')
+      item.setAttribute('aria-roledescription', 'slide')
+    })
+  }
+
+  _handleSlotChange() {
+    this._updateLayout()
+    this._updateScrollState()
+    this._syncActiveItem()
+    this.requestUpdate()
+  }
+
+  _handleKeyDown(event) {
+    const isRtlMode = isRtl(this, false)
+    const isLeft = event.key === 'ArrowLeft'
+    const isRight = event.key === 'ArrowRight'
+    const isHome = event.key === 'Home'
+    const isEnd = event.key === 'End'
+
+    if (!isLeft && !isRight && !isHome && !isEnd) {
+      return
+    }
+
+    event.preventDefault()
+
+    const forwards = isRtlMode ? isLeft : isRight
+    const backwards = isRtlMode ? isRight : isLeft
+
+    if (isHome) {
+      this.scrollToIndex(0)
+    } else if (isEnd) {
+      this.scrollToIndex(this.items.length - 1)
+    } else if (forwards) {
+      this.next()
+    } else if (backwards) {
+      this.previous()
+    }
+  }
+
+  _onPointerDown(e) {
+    if (e.button !== 0) return // Left-click only
+    const scroller = this.scrollerElement
+    if (!scroller) return
+
+    this._isPointerDown = true
+    this._startX = e.pageX - scroller.offsetLeft
+    this._startScrollLeft = scroller.scrollLeft
+    this._hasDragged = false
+  }
+
+  _onPointerMove(e) {
+    if (!this._isPointerDown) return
+    const scroller = this.scrollerElement
+    if (!scroller) return
+
+    const x = e.pageX - scroller.offsetLeft
+    const walk = (x - this._startX) * 1.2
+
+    if (Math.abs(walk) > 5) {
+      this._hasDragged = true
+      scroller.classList.add('is-dragging')
+      scroller.scrollLeft = this._startScrollLeft - walk
+    }
+  }
+
+  _onPointerUp() {
+    if (!this._isPointerDown) return
+    this._isPointerDown = false
+
+    const scroller = this.scrollerElement
+    if (scroller) {
+      scroller.classList.remove('is-dragging')
+    }
+
+    if (this._hasDragged) {
+      this._handleScroll()
+    }
+  }
+
+  _onPointerCancel() {
+    this._isPointerDown = false
+    const scroller = this.scrollerElement
+    if (scroller) {
+      scroller.classList.remove('is-dragging')
+    }
+  }
+
+  _startAutoplay() {
+    this._stopAutoplay()
+    const delay = Number(this.autoplay)
+    if (delay && delay > 0) {
+      this._autoplayTimer = setInterval(() => {
+        this.next()
+      }, delay)
+    }
+  }
+
+  _stopAutoplay() {
+    if (this._autoplayTimer) {
+      clearInterval(this._autoplayTimer)
+      this._autoplayTimer = null
+    }
+  }
+
+  _pauseAutoplay() {
+    this._stopAutoplay()
+  }
+
+  _resumeAutoplay() {
+    this._startAutoplay()
+  }
+
+  static styles = [
+    css`
+      :host {
+        display: block;
+        position: relative;
+        box-sizing: border-box;
+        width: 100%;
+        overflow: hidden;
+        border-radius: var(--md-carousel-shape, var(--md-sys-shape-corner-extra-large, 28px));
+        --_nav-button-size: 40px;
+        --_nav-button-color: var(--md-sys-color-surface-container-highest, #e6e0e9);
+        --_nav-button-icon-color: var(--md-sys-color-on-surface, #1d1b20);
+        --_indicator-color: var(--md-sys-color-outline-variant, #cac4d0);
+        --_indicator-active-color: var(--md-sys-color-primary, #6750a4);
+      }
+
+      .carousel-container {
+        display: flex;
+        flex-direction: column;
+        position: relative;
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        box-sizing: border-box;
+        overflow: hidden;
+        border-radius: inherit;
+      }
+
+      .scroller {
+        display: flex;
+        flex-direction: row;
+        flex: 1;
+        overflow-x: auto;
+        overflow-y: hidden;
+        scroll-behavior: smooth;
+        gap: var(--_item-spacing, 8px);
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        box-sizing: border-box;
+        outline: none;
+        user-select: none;
+        touch-action: pan-y pinch-zoom;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      ::slotted([md-carousel-item]),
+      ::slotted(md-carousel-item) {
+        height: 100%;
+        min-height: 0;
+      }
+
+      :host([scroll-snap]) .scroller:not(.is-dragging) {
+        scroll-snap-type: x mandatory;
+      }
+
+      :host([hide-scrollbar]) .scroller {
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+      }
+      :host([hide-scrollbar]) .scroller::-webkit-scrollbar {
+        display: none;
+      }
+
+      .scroller.is-dragging {
+        scroll-behavior: auto;
+        cursor: grabbing;
+      }
+      .scroller.is-dragging ::slotted(*) {
+        pointer-events: none;
+      }
+
+      /* Layout: Multi-Browse */
+      :host([layout='multi-browse']) ::slotted([md-carousel-item]),
+      :host([layout='multi-browse']) ::slotted(md-carousel-item),
+      :host(:not([layout])) ::slotted([md-carousel-item]),
+      :host(:not([layout])) ::slotted(md-carousel-item) {
+        flex: 0 0 var(--_large-item-width, 280px);
+        width: var(--_large-item-width, 280px);
+        scroll-snap-align: start;
+      }
+
+      /* Layout: Uncontained */
+      :host([layout='uncontained']) ::slotted([md-carousel-item]),
+      :host([layout='uncontained']) ::slotted(md-carousel-item) {
+        flex: 0 0 var(--_custom-item-width, 280px);
+        width: var(--_custom-item-width, 280px);
+        scroll-snap-align: start;
+      }
+
+      /* Layout: Hero (Start-aligned) */
+      :host([layout='hero']) ::slotted([md-carousel-item]),
+      :host([layout='hero']) ::slotted(md-carousel-item) {
+        flex: 0 0 calc(100% - 64px);
+        max-width: 600px;
+        width: calc(100% - 64px);
+        scroll-snap-align: start;
+      }
+
+      /* Layout: Centered Hero */
+      :host([layout='centered-hero']) .scroller {
+        padding-left: 56px;
+        padding-right: 56px;
+      }
+      :host([layout='centered-hero']) ::slotted([md-carousel-item]),
+      :host([layout='centered-hero']) ::slotted(md-carousel-item) {
+        flex: 0 0 calc(100% - 112px);
+        max-width: 600px;
+        width: calc(100% - 112px);
+        scroll-snap-align: center;
+      }
+
+      /* Layout: Full-Screen */
+      :host([layout='full-screen']) ::slotted([md-carousel-item]),
+      :host([layout='full-screen']) ::slotted(md-carousel-item) {
+        flex: 0 0 100%;
+        width: 100%;
+        height: 100%;
+        scroll-snap-align: start;
+      }
+
+      /* Navigation Buttons */
+      .nav-button {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        width: var(--_nav-button-size);
+        height: var(--_nav-button-size);
+        border-radius: 50%;
+        background: var(--_nav-button-color);
+        color: var(--_nav-button-icon-color);
+        border: none;
+        outline: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        z-index: 10;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+        transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1),
+                    transform 0.2s cubic-bezier(0.2, 0, 0, 1),
+                    background-color 0.2s cubic-bezier(0.2, 0, 0, 1);
+        -webkit-tap-highlight-color: transparent;
+      }
+
+      .nav-button md-elevation {
+        --md-elevation-level: 2;
+        border-radius: 50%;
+      }
+
+      .nav-button md-focus-ring {
+        --md-focus-ring-shape: 50%;
+      }
+
+      .nav-button.prev {
+        left: 12px;
+      }
+
+      .nav-button.next {
+        right: 12px;
+      }
+
+      .nav-button.disabled,
+      .nav-button:disabled {
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      :host([navigation='auto']) .nav-button {
+        opacity: 0;
+      }
+
+      :host([navigation='auto']:hover) .nav-button:not(.disabled),
+      :host([navigation='auto']:focus-within) .nav-button:not(.disabled) {
+        opacity: 0.92;
+      }
+
+      :host([navigation='auto']:hover) .nav-button:not(.disabled):hover {
+        opacity: 1;
+        transform: translateY(-50%) scale(1.06);
+      }
+
+      :host([navigation='always']) .nav-button:not(.disabled) {
+        opacity: 0.92;
+      }
+      :host([navigation='always']) .nav-button:not(.disabled):hover {
+        opacity: 1;
+        transform: translateY(-50%) scale(1.06);
+      }
+
+      /* Indicators */
+      .indicators {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        margin-top: 12px;
+        width: 100%;
+      }
+
+      .indicator-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 4px;
+        background: var(--_indicator-color);
+        border: none;
+        outline: none;
+        padding: 0;
+        cursor: pointer;
+        transition: width 0.3s cubic-bezier(0.2, 0, 0, 1),
+                    background-color 0.3s cubic-bezier(0.2, 0, 0, 1);
+      }
+
+      .indicator-dot.active {
+        width: 24px;
+        background: var(--_indicator-active-color);
+      }
+
+      .indicator-dot:hover:not(.active) {
+        background: var(--md-sys-color-outline, #79747e);
+      }
+    `,
+  ]
+}
+
+customElements.define('md-carousel', Carousel)

--- a/carousel/carousel.js
+++ b/carousel/carousel.js
@@ -311,34 +311,11 @@ export class Carousel extends LitElement {
         scroller.style.paddingRight = '0px'
       }
 
-      const isCompact = containerWidth < 520
-      const isMedium = containerWidth >= 520 && containerWidth < 840
-      const isExpanded = containerWidth >= 840
-
-      let numLarge = isExpanded ? 2 : 1
-      const smallWidth = isCompact ? 48 : 56
-      let mediumWidth
-      let largeWidth
-
-      if (isCompact) {
-        if (containerWidth < 360) {
-          numLarge = 1
-          mediumWidth = 0
-          largeWidth = Math.max(180, containerWidth - smallWidth - spacing)
-        } else {
-          const remaining = containerWidth - smallWidth - 2 * spacing
-          mediumWidth = Math.max(72, Math.min(120, Math.round(remaining * 0.28)))
-          largeWidth = Math.max(180, remaining - mediumWidth)
-        }
-      } else if (isMedium) {
-        const remaining = containerWidth - smallWidth - 2 * spacing
-        mediumWidth = Math.max(120, Math.min(180, Math.round(remaining * 0.3)))
-        largeWidth = Math.max(260, remaining - mediumWidth)
-      } else {
-        const remaining = containerWidth - smallWidth - 3 * spacing
-        mediumWidth = Math.max(140, Math.min(220, Math.round(remaining * 0.22)))
-        largeWidth = Math.max(280, Math.floor((remaining - mediumWidth) / 2))
-      }
+      const smallWidth = containerWidth < 400 ? 40 : containerWidth < 600 ? 48 : 56
+      const remaining = Math.max(120, containerWidth - smallWidth - 2 * spacing)
+      const mediumRatio = containerWidth < 400 ? 0.3 : 0.32
+      const mediumWidth = Math.max(60, Math.round(remaining * mediumRatio))
+      const largeWidth = Math.max(120, remaining - mediumWidth)
 
       items.forEach((item, i) => {
         let sizeType = 'large'
@@ -347,13 +324,13 @@ export class Carousel extends LitElement {
         if (i < activeIndex) {
           sizeType = 'small'
           width = smallWidth
-        } else if (i < activeIndex + numLarge) {
+        } else if (i === activeIndex) {
           sizeType = 'large'
           width = largeWidth
-        } else if (mediumWidth > 0 && i === activeIndex + numLarge) {
+        } else if (i === activeIndex + 1) {
           sizeType = 'medium'
           width = mediumWidth
-        } else if (i === activeIndex + numLarge + (mediumWidth > 0 ? 1 : 0)) {
+        } else if (i === activeIndex + 2) {
           sizeType = 'small'
           width = smallWidth
         } else {

--- a/carousel/carousel.js
+++ b/carousel/carousel.js
@@ -123,11 +123,7 @@ export class Carousel extends LitElement {
   }
 
   updated(changedProperties) {
-    if (
-      changedProperties.has('layout') ||
-      changedProperties.has('itemWidth') ||
-      changedProperties.has('itemSpacing')
-    ) {
+    if (changedProperties.has('layout') || changedProperties.has('itemWidth') || changedProperties.has('itemSpacing')) {
       this._updateLayout()
       this._updateScrollState()
     }
@@ -137,6 +133,7 @@ export class Carousel extends LitElement {
     }
 
     if (changedProperties.has('activeIndex') && changedProperties.get('activeIndex') !== undefined) {
+      this._applyItemSizes()
       this._syncActiveItem()
     }
   }
@@ -254,12 +251,16 @@ export class Carousel extends LitElement {
     if (!items.length || !this.scrollerElement) return
 
     const boundedIndex = Math.max(0, Math.min(index, items.length - 1))
-    const targetItem = items[boundedIndex]
-    if (!targetItem) return
+    this.activeIndex = boundedIndex
+    this._applyItemSizes()
+    this._syncActiveItem()
+
+    // Wait a frame for CSS transitions / layout to settle
+    await new Promise((r) => requestAnimationFrame(r))
 
     const scroller = this.scrollerElement
-    const scrollerRect = scroller.getBoundingClientRect()
-    const itemRect = targetItem.getBoundingClientRect()
+    const targetItem = items[boundedIndex]
+    if (!targetItem || !scroller) return
 
     let scrollTarget
     if (this.layout === 'centered-hero') {
@@ -275,44 +276,189 @@ export class Carousel extends LitElement {
       behavior,
     })
 
-    this.activeIndex = boundedIndex
-    this._syncActiveItem()
+    this._updateScrollState()
+    this.dispatchEvent(
+      new CustomEvent('change', {
+        detail: { index: boundedIndex, item: targetItem },
+        bubbles: true,
+        composed: true,
+      }),
+    )
   }
 
   _updateLayout() {
     const scroller = this.scrollerElement
     if (!scroller) return
 
-    const containerWidth = this.offsetWidth || scroller.clientWidth || 360
     const spacing = Number(this.itemSpacing) || 8
-
     scroller.style.setProperty('--_item-spacing', `${spacing}px`)
 
-    if (this.itemWidth) {
-      const widthVal = isNaN(Number(this.itemWidth)) ? this.itemWidth : `${this.itemWidth}px`
-      scroller.style.setProperty('--_custom-item-width', widthVal)
-    } else {
-      scroller.style.removeProperty('--_custom-item-width')
-    }
+    this._applyItemSizes()
+  }
 
-    if (this.layout === 'multi-browse') {
-      // Dynamic M3 Multi-browse item calculations
-      const smallWidth = 48
-      const availableWidth = containerWidth - smallWidth - spacing
+  _applyItemSizes() {
+    const items = this.items
+    if (!items.length) return
 
-      let largeWidth
-      if (containerWidth < 480) {
-        // Compact: 1 large + 1 small peek
-        largeWidth = Math.max(220, availableWidth)
-      } else if (containerWidth < 768) {
-        // Medium: 1 large (~65%) + 1 medium (~30%) + 1 small peek
-        largeWidth = Math.min(360, Math.floor(availableWidth * 0.65))
-      } else {
-        // Expanded: 2 or more large + medium + small peek
-        largeWidth = Math.min(400, Math.floor(availableWidth * 0.42))
+    const scroller = this.scrollerElement
+    const containerWidth = this.offsetWidth || scroller?.clientWidth || 360
+    const spacing = Number(this.itemSpacing) || 8
+    const activeIndex = this.activeIndex
+
+    if (this.layout === 'multi-browse' || !this.layout) {
+      if (scroller) {
+        scroller.style.paddingLeft = '0px'
+        scroller.style.paddingRight = '0px'
       }
 
-      scroller.style.setProperty('--_large-item-width', `${largeWidth}px`)
+      const isCompact = containerWidth < 520
+      const isMedium = containerWidth >= 520 && containerWidth < 840
+      const isExpanded = containerWidth >= 840
+
+      let numLarge = isExpanded ? 2 : 1
+      const smallWidth = isCompact ? 48 : 56
+      let mediumWidth
+      let largeWidth
+
+      if (isCompact) {
+        if (containerWidth < 360) {
+          numLarge = 1
+          mediumWidth = 0
+          largeWidth = Math.max(180, containerWidth - smallWidth - spacing)
+        } else {
+          const remaining = containerWidth - smallWidth - 2 * spacing
+          mediumWidth = Math.max(72, Math.min(120, Math.round(remaining * 0.28)))
+          largeWidth = Math.max(180, remaining - mediumWidth)
+        }
+      } else if (isMedium) {
+        const remaining = containerWidth - smallWidth - 2 * spacing
+        mediumWidth = Math.max(120, Math.min(180, Math.round(remaining * 0.3)))
+        largeWidth = Math.max(260, remaining - mediumWidth)
+      } else {
+        const remaining = containerWidth - smallWidth - 3 * spacing
+        mediumWidth = Math.max(140, Math.min(220, Math.round(remaining * 0.22)))
+        largeWidth = Math.max(280, Math.floor((remaining - mediumWidth) / 2))
+      }
+
+      items.forEach((item, i) => {
+        let sizeType = 'large'
+        let width = largeWidth
+
+        if (i < activeIndex) {
+          sizeType = 'small'
+          width = smallWidth
+        } else if (i < activeIndex + numLarge) {
+          sizeType = 'large'
+          width = largeWidth
+        } else if (mediumWidth > 0 && i === activeIndex + numLarge) {
+          sizeType = 'medium'
+          width = mediumWidth
+        } else if (i === activeIndex + numLarge + (mediumWidth > 0 ? 1 : 0)) {
+          sizeType = 'small'
+          width = smallWidth
+        } else {
+          sizeType = 'large'
+          width = largeWidth
+        }
+
+        item.setAttribute('data-size', sizeType)
+        item.style.flex = `0 0 ${width}px`
+        item.style.width = `${width}px`
+        item.style.minWidth = `${width}px`
+        item.style.maxWidth = `${width}px`
+      })
+    } else if (this.layout === 'hero') {
+      if (scroller) {
+        scroller.style.paddingLeft = '0px'
+        scroller.style.paddingRight = '0px'
+      }
+
+      const smallWidth = containerWidth < 480 ? 48 : 56
+      const largeWidth = Math.max(240, containerWidth - smallWidth - spacing)
+
+      items.forEach((item, i) => {
+        let sizeType = 'large'
+        let width = largeWidth
+
+        if (i < activeIndex) {
+          sizeType = 'small'
+          width = smallWidth
+        } else if (i === activeIndex) {
+          sizeType = 'large'
+          width = largeWidth
+        } else if (i === activeIndex + 1) {
+          sizeType = 'small'
+          width = smallWidth
+        } else {
+          sizeType = 'large'
+          width = largeWidth
+        }
+
+        item.setAttribute('data-size', sizeType)
+        item.style.flex = `0 0 ${width}px`
+        item.style.width = `${width}px`
+        item.style.minWidth = `${width}px`
+        item.style.maxWidth = `${width}px`
+      })
+    } else if (this.layout === 'centered-hero') {
+      const peekWidth = containerWidth < 480 ? 40 : 56
+      const largeWidth = Math.max(220, containerWidth - 2 * peekWidth - 2 * spacing)
+
+      if (scroller) {
+        scroller.style.paddingLeft = `${peekWidth + spacing}px`
+        scroller.style.paddingRight = `${peekWidth + spacing}px`
+      }
+
+      items.forEach((item, i) => {
+        let sizeType = 'large'
+        let width = largeWidth
+
+        if (i === activeIndex) {
+          sizeType = 'large'
+          width = largeWidth
+        } else if (i === activeIndex - 1 || i === activeIndex + 1) {
+          sizeType = 'small'
+          width = peekWidth
+        } else {
+          sizeType = 'large'
+          width = largeWidth
+        }
+
+        item.setAttribute('data-size', sizeType)
+        item.style.flex = `0 0 ${width}px`
+        item.style.width = `${width}px`
+        item.style.minWidth = `${width}px`
+        item.style.maxWidth = `${width}px`
+      })
+    } else if (this.layout === 'uncontained') {
+      if (scroller) {
+        scroller.style.paddingLeft = '0px'
+        scroller.style.paddingRight = '0px'
+      }
+      const customWidth = this.itemWidth
+        ? isNaN(Number(this.itemWidth))
+          ? this.itemWidth
+          : `${this.itemWidth}px`
+        : '280px'
+      items.forEach((item) => {
+        item.setAttribute('data-size', 'large')
+        item.style.flex = `0 0 ${customWidth}`
+        item.style.width = customWidth
+        item.style.minWidth = customWidth
+        item.style.maxWidth = customWidth
+      })
+    } else if (this.layout === 'full-screen') {
+      if (scroller) {
+        scroller.style.paddingLeft = '0px'
+        scroller.style.paddingRight = '0px'
+      }
+      items.forEach((item) => {
+        item.setAttribute('data-size', 'large')
+        item.style.flex = '0 0 100%'
+        item.style.width = '100%'
+        item.style.minWidth = '100%'
+        item.style.maxWidth = '100%'
+      })
     }
   }
 
@@ -334,20 +480,19 @@ export class Carousel extends LitElement {
     const items = this.items
     if (!scroller || !items.length) return
 
-    const scrollerRect = scroller.getBoundingClientRect()
-    const scrollerCenter = scrollerRect.left + scrollerRect.width / 2
+    const scrollerLeft = scroller.scrollLeft
+    const scrollerCenter = scrollerLeft + scroller.clientWidth / 2
 
     let closestIndex = 0
     let minDistance = Infinity
 
     items.forEach((item, index) => {
-      const rect = item.getBoundingClientRect()
       let distance
       if (this.layout === 'centered-hero') {
-        const itemCenter = rect.left + rect.width / 2
+        const itemCenter = item.offsetLeft + item.offsetWidth / 2
         distance = Math.abs(itemCenter - scrollerCenter)
       } else {
-        distance = Math.abs(rect.left - scrollerRect.left)
+        distance = Math.abs(item.offsetLeft - scrollerLeft)
       }
 
       if (distance < minDistance) {
@@ -358,6 +503,7 @@ export class Carousel extends LitElement {
 
     if (this.activeIndex !== closestIndex) {
       this.activeIndex = closestIndex
+      this._applyItemSizes()
       this._syncActiveItem()
       this.dispatchEvent(
         new CustomEvent('change', {
@@ -387,6 +533,8 @@ export class Carousel extends LitElement {
   }
 
   _handleKeyDown(event) {
+    if (event.defaultPrevented) return
+
     const isRtlMode = isRtl(this, false)
     const isLeft = event.key === 'ArrowLeft'
     const isRight = event.key === 'ArrowRight'
@@ -422,6 +570,10 @@ export class Carousel extends LitElement {
     this._startX = e.pageX - scroller.offsetLeft
     this._startScrollLeft = scroller.scrollLeft
     this._hasDragged = false
+
+    try {
+      scroller.setPointerCapture?.(e.pointerId)
+    } catch {}
   }
 
   _onPointerMove(e) {
@@ -439,13 +591,18 @@ export class Carousel extends LitElement {
     }
   }
 
-  _onPointerUp() {
+  _onPointerUp(e) {
     if (!this._isPointerDown) return
     this._isPointerDown = false
 
     const scroller = this.scrollerElement
     if (scroller) {
       scroller.classList.remove('is-dragging')
+      try {
+        if (e && scroller.hasPointerCapture?.(e.pointerId)) {
+          scroller.releasePointerCapture?.(e.pointerId)
+        }
+      } catch {}
     }
 
     if (this._hasDragged) {
@@ -453,11 +610,16 @@ export class Carousel extends LitElement {
     }
   }
 
-  _onPointerCancel() {
+  _onPointerCancel(e) {
     this._isPointerDown = false
     const scroller = this.scrollerElement
     if (scroller) {
       scroller.classList.remove('is-dragging')
+      try {
+        if (e && scroller.hasPointerCapture?.(e.pointerId)) {
+          scroller.releasePointerCapture?.(e.pointerId)
+        }
+      } catch {}
     }
   }
 
@@ -558,53 +720,17 @@ export class Carousel extends LitElement {
         pointer-events: none;
       }
 
-      /* Layout: Multi-Browse */
-      :host([layout='multi-browse']) ::slotted([md-carousel-item]),
-      :host([layout='multi-browse']) ::slotted(md-carousel-item),
-      :host(:not([layout])) ::slotted([md-carousel-item]),
-      :host(:not([layout])) ::slotted(md-carousel-item) {
-        flex: 0 0 var(--_large-item-width, 280px);
-        width: var(--_large-item-width, 280px);
+      /* Layout alignments */
+      ::slotted([md-carousel-item]),
+      ::slotted(md-carousel-item) {
+        height: 100%;
+        min-height: 0;
         scroll-snap-align: start;
       }
 
-      /* Layout: Uncontained */
-      :host([layout='uncontained']) ::slotted([md-carousel-item]),
-      :host([layout='uncontained']) ::slotted(md-carousel-item) {
-        flex: 0 0 var(--_custom-item-width, 280px);
-        width: var(--_custom-item-width, 280px);
-        scroll-snap-align: start;
-      }
-
-      /* Layout: Hero (Start-aligned) */
-      :host([layout='hero']) ::slotted([md-carousel-item]),
-      :host([layout='hero']) ::slotted(md-carousel-item) {
-        flex: 0 0 calc(100% - 64px);
-        max-width: 600px;
-        width: calc(100% - 64px);
-        scroll-snap-align: start;
-      }
-
-      /* Layout: Centered Hero */
-      :host([layout='centered-hero']) .scroller {
-        padding-left: 56px;
-        padding-right: 56px;
-      }
       :host([layout='centered-hero']) ::slotted([md-carousel-item]),
       :host([layout='centered-hero']) ::slotted(md-carousel-item) {
-        flex: 0 0 calc(100% - 112px);
-        max-width: 600px;
-        width: calc(100% - 112px);
         scroll-snap-align: center;
-      }
-
-      /* Layout: Full-Screen */
-      :host([layout='full-screen']) ::slotted([md-carousel-item]),
-      :host([layout='full-screen']) ::slotted(md-carousel-item) {
-        flex: 0 0 100%;
-        width: 100%;
-        height: 100%;
-        scroll-snap-align: start;
       }
 
       /* Navigation Buttons */
@@ -625,9 +751,10 @@ export class Carousel extends LitElement {
         cursor: pointer;
         z-index: 10;
         box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-        transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1),
-                    transform 0.2s cubic-bezier(0.2, 0, 0, 1),
-                    background-color 0.2s cubic-bezier(0.2, 0, 0, 1);
+        transition:
+          opacity 0.2s cubic-bezier(0.2, 0, 0, 1),
+          transform 0.2s cubic-bezier(0.2, 0, 0, 1),
+          background-color 0.2s cubic-bezier(0.2, 0, 0, 1);
         -webkit-tap-highlight-color: transparent;
       }
 
@@ -696,8 +823,9 @@ export class Carousel extends LitElement {
         outline: none;
         padding: 0;
         cursor: pointer;
-        transition: width 0.3s cubic-bezier(0.2, 0, 0, 1),
-                    background-color 0.3s cubic-bezier(0.2, 0, 0, 1);
+        transition:
+          width 0.3s cubic-bezier(0.2, 0, 0, 1),
+          background-color 0.3s cubic-bezier(0.2, 0, 0, 1);
       }
 
       .indicator-dot.active {

--- a/common.js
+++ b/common.js
@@ -7,6 +7,8 @@
  * for production.
  */
 import './buttons/button.js'
+import './carousel/carousel.js'
+import './carousel/carousel-item.js'
 import './checkbox/checkbox.js'
 import './chips/chip.js'
 import './chips/chip-set.js'
@@ -27,6 +29,8 @@ import './tabs/tabs.js'
 import './text/text-field.js'
 
 export * from './buttons/button.js'
+export * from './carousel/carousel.js'
+export * from './carousel/carousel-item.js'
 export * from './checkbox/checkbox.js'
 export * from './chips/chip.js'
 export * from './chips/chip-set.js'

--- a/demo/carousel-demo.html
+++ b/demo/carousel-demo.html
@@ -150,11 +150,11 @@
     </script>
 
     <div style="margin-bottom: 24px">
-      <a href="./index.html" style="display: inline-flex; align-items: center; gap: 4px; font-weight: 500;">
+      <a href="./index.html" style="display: inline-flex; align-items: center; gap: 4px; font-weight: 500">
         <md-icon>arrow_back</md-icon> Back to Main Demo
       </a>
-      <h1 style="margin-top: 12px; margin-bottom: 8px;">Material 3 Carousel</h1>
-      <p style="color: var(--md-sys-color-on-surface-variant, #49454f); margin: 0;">
+      <h1 style="margin-top: 12px; margin-bottom: 8px">Material 3 Carousel</h1>
+      <p style="color: var(--md-sys-color-on-surface-variant, #49454f); margin: 0">
         Interactive implementation of Google's Material Design 3 Carousel specification.
       </p>
     </div>
@@ -163,17 +163,17 @@
     <div class="demo-section">
       <div class="section-header">
         <h2 class="section-title">Interactive Playground</h2>
-        <span id="activeSlideStatus" style="font-weight: 500; color: var(--md-sys-color-primary, #6750a4);">
+        <span id="activeSlideStatus" style="font-weight: 500; color: var(--md-sys-color-primary, #6750a4)">
           Active Slide: 1 / 6
         </span>
       </div>
-      <p class="section-desc">
-        Change the layout strategy, toggle indicators, autoplay, or navigate programmatically.
-      </p>
+      <p class="section-desc">Change the layout strategy, toggle indicators, autoplay, or navigate programmatically.</p>
 
       <div class="controls-bar">
         <label><strong>Layout:</strong></label>
-        <select id="layoutSelect" style="padding: 8px 12px; border-radius: 8px; border: 1px solid #ccc; background: white;">
+        <select
+          id="layoutSelect"
+          style="padding: 8px 12px; border-radius: 8px; border: 1px solid #ccc; background: white">
           <option value="multi-browse" selected>Multi-Browse</option>
           <option value="uncontained">Uncontained</option>
           <option value="hero">Hero (Start-aligned)</option>
@@ -181,25 +181,34 @@
           <option value="full-screen">Full-Screen</option>
         </select>
 
-        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer">
           <input type="checkbox" id="indicatorsToggle" checked /> Indicators
         </label>
 
-        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer">
           <input type="checkbox" id="loopToggle" checked /> Loop
         </label>
 
-        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer">
           <input type="checkbox" id="autoplayToggle" /> Autoplay (3s)
         </label>
 
-        <div style="margin-left: auto; display: flex; gap: 8px;">
+        <label style="display: flex; align-items: center; gap: 8px; font-size: 0.9rem">
+          <strong>Container Width:</strong>
+          <input type="range" id="widthSlider" min="320" max="952" value="952" style="cursor: pointer; width: 120px" />
+          <span id="widthValue" style="min-width: 48px; font-variant-numeric: tabular-nums">100%</span>
+        </label>
+
+        <div style="margin-left: auto; display: flex; gap: 8px">
           <md-button color="outlined" id="prevBtn">Previous</md-button>
           <md-button color="filled" id="nextBtn">Next</md-button>
         </div>
       </div>
 
-      <div class="carousel-wrapper tall">
+      <div
+        id="playgroundWrapper"
+        class="carousel-wrapper tall"
+        style="transition: width 0.3s cubic-bezier(0.2, 0, 0, 1)">
         <md-carousel id="playgroundCarousel" layout="multi-browse" indicators loop>
           <md-carousel-item interactive headline="Mountain Vista" subhead="Rocky Peaks National Park">
             <span class="badge-tag">Featured</span>
@@ -229,7 +238,8 @@
     <div class="demo-section">
       <h2 class="section-title">1. Multi-Browse Layout (Default)</h2>
       <p class="section-desc">
-        Displays items of varying sizes (large, medium, and small peek). Dynamically recalculates item widths as the container resizes.
+        Displays items of varying sizes (large, medium, and small peek). Dynamically recalculates item widths as the
+        container resizes.
       </p>
 
       <div class="carousel-wrapper">
@@ -257,7 +267,8 @@
     <div class="demo-section">
       <h2 class="section-title">2. Uncontained Layout with Custom Cards</h2>
       <p class="section-desc">
-        Displays uniform width items scrolling across the container boundary. Excellent for cards, articles, and text-heavy items.
+        Displays uniform width items scrolling across the container boundary. Excellent for cards, articles, and
+        text-heavy items.
       </p>
 
       <div class="carousel-wrapper">
@@ -265,12 +276,12 @@
           <md-carousel-item type="elevated" interactive>
             <div class="custom-card">
               <div>
-                <h3 style="margin-top: 0; margin-bottom: 8px;">Explore Components</h3>
-                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4;">
+                <h3 style="margin-top: 0; margin-bottom: 8px">Explore Components</h3>
+                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4">
                   Discover Material 3 Expressive buttons, pickers, cards, navigation, and carousels.
                 </p>
               </div>
-              <div style="display: flex; justify-content: flex-end;">
+              <div style="display: flex; justify-content: flex-end">
                 <md-button color="tonal">Learn more</md-button>
               </div>
             </div>
@@ -279,12 +290,12 @@
           <md-carousel-item type="filled" interactive>
             <div class="custom-card">
               <div>
-                <h3 style="margin-top: 0; margin-bottom: 8px;">Design Tokens</h3>
-                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4;">
+                <h3 style="margin-top: 0; margin-bottom: 8px">Design Tokens</h3>
+                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4">
                   Full support for dynamic color schemes, shape tokens, and typography scales.
                 </p>
               </div>
-              <div style="display: flex; justify-content: flex-end;">
+              <div style="display: flex; justify-content: flex-end">
                 <md-button color="tonal">Customize</md-button>
               </div>
             </div>
@@ -293,12 +304,12 @@
           <md-carousel-item type="outlined" interactive>
             <div class="custom-card">
               <div>
-                <h3 style="margin-top: 0; margin-bottom: 8px;">Web Components</h3>
-                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4;">
+                <h3 style="margin-top: 0; margin-bottom: 8px">Web Components</h3>
+                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4">
                   Standards-compliant Lit web components with seamless framework compatibility.
                 </p>
               </div>
-              <div style="display: flex; justify-content: flex-end;">
+              <div style="display: flex; justify-content: flex-end">
                 <md-button color="tonal">Get Started</md-button>
               </div>
             </div>
@@ -307,12 +318,12 @@
           <md-carousel-item type="elevated" interactive>
             <div class="custom-card">
               <div>
-                <h3 style="margin-top: 0; margin-bottom: 8px;">Responsive Layouts</h3>
-                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4;">
+                <h3 style="margin-top: 0; margin-bottom: 8px">Responsive Layouts</h3>
+                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4">
                   Auto-adapting layouts with smooth touch, trackpad, and mouse drag interactions.
                 </p>
               </div>
-              <div style="display: flex; justify-content: flex-end;">
+              <div style="display: flex; justify-content: flex-end">
                 <md-button color="tonal">View Docs</md-button>
               </div>
             </div>
@@ -324,17 +335,21 @@
     <!-- 3. Hero Layout (Start-aligned) -->
     <div class="demo-section">
       <h2 class="section-title">3. Hero Layout (Start-aligned)</h2>
-      <p class="section-desc">
-        Spotlights one dominant large item with a smaller peek item on the trailing side.
-      </p>
+      <p class="section-desc">Spotlights one dominant large item with a smaller peek item on the trailing side.</p>
 
       <div class="carousel-wrapper tall">
         <md-carousel layout="hero" indicators loop>
-          <md-carousel-item interactive headline="Summer Spotlight Series" subhead="Curated collections from top photographers">
+          <md-carousel-item
+            interactive
+            headline="Summer Spotlight Series"
+            subhead="Curated collections from top photographers">
             <span class="badge-tag">Editor's Pick</span>
             <img src="./images/img3.jpg" alt="Summer Spotlight" />
           </md-carousel-item>
-          <md-carousel-item interactive headline="Pacific Northwest" subhead="Scenic coastal highways & ancient forests">
+          <md-carousel-item
+            interactive
+            headline="Pacific Northwest"
+            subhead="Scenic coastal highways & ancient forests">
             <span class="badge-tag">Popular</span>
             <img src="./images/img4.jpg" alt="Pacific Northwest" />
           </md-carousel-item>
@@ -348,9 +363,7 @@
     <!-- 4. Centered Hero Layout -->
     <div class="demo-section">
       <h2 class="section-title">4. Centered Hero Layout</h2>
-      <p class="section-desc">
-        Centers one large focal item flanked by peek items on both the left and right edges.
-      </p>
+      <p class="section-desc">Centers one large focal item flanked by peek items on both the left and right edges.</p>
 
       <div class="carousel-wrapper tall">
         <md-carousel layout="centered-hero" indicators loop>
@@ -373,19 +386,23 @@
     <!-- 5. Full-Screen Layout with Autoplay -->
     <div class="demo-section">
       <h2 class="section-title">5. Full-Screen Layout with Autoplay (4s)</h2>
-      <p class="section-desc">
-        Edge-to-edge full width slide presentation with pagination and hover-pause autoplay.
-      </p>
+      <p class="section-desc">Edge-to-edge full width slide presentation with pagination and hover-pause autoplay.</p>
 
       <div class="carousel-wrapper full">
         <md-carousel layout="full-screen" indicators loop autoplay="4000">
-          <md-carousel-item headline="Design Systems Reimagined" subhead="Building cohesive, accessible experiences across web & mobile">
+          <md-carousel-item
+            headline="Design Systems Reimagined"
+            subhead="Building cohesive, accessible experiences across web & mobile">
             <img src="./images/img1.jpg" alt="Slide 1" />
           </md-carousel-item>
-          <md-carousel-item headline="Fluid Responsive Components" subhead="Seamlessly scaling from compact smartphones to desktop displays">
+          <md-carousel-item
+            headline="Fluid Responsive Components"
+            subhead="Seamlessly scaling from compact smartphones to desktop displays">
             <img src="./images/img2.jpg" alt="Slide 2" />
           </md-carousel-item>
-          <md-carousel-item headline="Material 3 Expressive Power" subhead="Modern shapes, dynamic color schemes, and tactile motion">
+          <md-carousel-item
+            headline="Material 3 Expressive Power"
+            subhead="Modern shapes, dynamic color schemes, and tactile motion">
             <img src="./images/img4.jpg" alt="Slide 3" />
           </md-carousel-item>
         </md-carousel>
@@ -403,6 +420,10 @@
       const nextBtn = document.getElementById('nextBtn')
       const statusSpan = document.getElementById('activeSlideStatus')
 
+      const widthSlider = document.getElementById('widthSlider')
+      const widthValue = document.getElementById('widthValue')
+      const playgroundWrapper = document.getElementById('playgroundWrapper')
+
       layoutSelect.addEventListener('change', (e) => {
         carousel.layout = e.target.value
       })
@@ -417,6 +438,17 @@
 
       autoplayToggle.addEventListener('change', (e) => {
         carousel.autoplay = e.target.checked ? 3000 : 0
+      })
+
+      widthSlider.addEventListener('input', (e) => {
+        const val = Number(e.target.value)
+        if (val >= 940) {
+          playgroundWrapper.style.width = '100%'
+          widthValue.textContent = '100%'
+        } else {
+          playgroundWrapper.style.width = `${val}px`
+          widthValue.textContent = `${val}px`
+        }
       })
 
       prevBtn.addEventListener('click', () => carousel.previous())

--- a/demo/carousel-demo.html
+++ b/demo/carousel-demo.html
@@ -1,0 +1,431 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Material 3 Carousel Demo</title>
+
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap"
+      as="style"
+      onload="
+        this.onload = null
+        this.rel = 'stylesheet'
+      " />
+    <link
+      rel="preload"
+      href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght@400;500;700&display=swap"
+      as="style"
+      onload="
+        this.onload = null
+        this.rel = 'stylesheet'
+      " />
+
+    <link rel="icon" href="./images/material.jpeg" />
+    <link rel="stylesheet" href="./css/styles.css" />
+
+    <script type="importmap">
+      {
+        "imports": {
+          "lit": "https://cdn.jsdelivr.net/npm/lit@3/index.js",
+          "lit/": "https://cdn.jsdelivr.net/npm/lit@3/",
+          "@lit/localize": "https://cdn.jsdelivr.net/npm/@lit/localize/lit-localize.js",
+          "@lit/reactive-element": "https://cdn.jsdelivr.net/npm/@lit/reactive-element@2/reactive-element.js",
+          "@lit/reactive-element/": "https://cdn.jsdelivr.net/npm/@lit/reactive-element@2/",
+          "lit-element/lit-element.js": "https://cdn.jsdelivr.net/npm/lit-element@4/lit-element.js",
+          "lit-html": "https://cdn.jsdelivr.net/npm/lit-html@3/lit-html.js",
+          "lit-html/": "https://cdn.jsdelivr.net/npm/lit-html@3/",
+          "material/": "../"
+        }
+      }
+    </script>
+
+    <style>
+      body {
+        background: var(--md-sys-color-background, #fef7ff);
+        color: var(--md-sys-color-on-background, #1d1b20);
+        padding: 24px;
+        max-width: 1000px;
+        margin: 0 auto;
+        box-sizing: border-box;
+      }
+
+      .demo-section {
+        margin-bottom: 48px;
+        background: var(--md-sys-color-surface-container, #f3edf7);
+        border-radius: 24px;
+        padding: 24px;
+        box-sizing: border-box;
+      }
+
+      .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 16px;
+      }
+
+      .section-title {
+        font-size: 1.25rem;
+        font-weight: 500;
+        margin: 0;
+      }
+
+      .section-desc {
+        color: var(--md-sys-color-on-surface-variant, #49454f);
+        margin-top: 4px;
+        margin-bottom: 16px;
+        font-size: 0.9rem;
+      }
+
+      .carousel-wrapper {
+        height: 240px;
+        margin-bottom: 12px;
+        position: relative;
+      }
+
+      .carousel-wrapper md-carousel {
+        height: 100%;
+      }
+
+      .carousel-wrapper.tall {
+        height: 340px;
+      }
+
+      .carousel-wrapper.full {
+        height: 380px;
+      }
+
+      .badge-tag {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        background: rgba(0, 0, 0, 0.6);
+        color: #fff;
+        padding: 4px 10px;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 500;
+        backdrop-filter: blur(4px);
+        z-index: 4;
+      }
+
+      .controls-bar {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        flex-wrap: wrap;
+        margin-bottom: 24px;
+        padding: 16px;
+        background: var(--md-sys-color-surface-container-high, #ece6f0);
+        border-radius: 16px;
+      }
+
+      .custom-card {
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        height: 100%;
+        box-sizing: border-box;
+      }
+    </style>
+  </head>
+
+  <body>
+    <script type="module">
+      import 'material/carousel/carousel.js'
+      import 'material/carousel/carousel-item.js'
+      import 'material/card/card.js'
+      import 'material/buttons/button.js'
+      import 'material/buttons/icon-button.js'
+      import 'material/chips/chip.js'
+      import 'material/chips/chip-set.js'
+      import 'material/icon/icon.js'
+      import 'material/badge/badge.js'
+    </script>
+
+    <div style="margin-bottom: 24px">
+      <a href="./index.html" style="display: inline-flex; align-items: center; gap: 4px; font-weight: 500;">
+        <md-icon>arrow_back</md-icon> Back to Main Demo
+      </a>
+      <h1 style="margin-top: 12px; margin-bottom: 8px;">Material 3 Carousel</h1>
+      <p style="color: var(--md-sys-color-on-surface-variant, #49454f); margin: 0;">
+        Interactive implementation of Google's Material Design 3 Carousel specification.
+      </p>
+    </div>
+
+    <!-- Interactive Playground -->
+    <div class="demo-section">
+      <div class="section-header">
+        <h2 class="section-title">Interactive Playground</h2>
+        <span id="activeSlideStatus" style="font-weight: 500; color: var(--md-sys-color-primary, #6750a4);">
+          Active Slide: 1 / 6
+        </span>
+      </div>
+      <p class="section-desc">
+        Change the layout strategy, toggle indicators, autoplay, or navigate programmatically.
+      </p>
+
+      <div class="controls-bar">
+        <label><strong>Layout:</strong></label>
+        <select id="layoutSelect" style="padding: 8px 12px; border-radius: 8px; border: 1px solid #ccc; background: white;">
+          <option value="multi-browse" selected>Multi-Browse</option>
+          <option value="uncontained">Uncontained</option>
+          <option value="hero">Hero (Start-aligned)</option>
+          <option value="centered-hero">Centered Hero</option>
+          <option value="full-screen">Full-Screen</option>
+        </select>
+
+        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+          <input type="checkbox" id="indicatorsToggle" checked /> Indicators
+        </label>
+
+        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+          <input type="checkbox" id="loopToggle" checked /> Loop
+        </label>
+
+        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+          <input type="checkbox" id="autoplayToggle" /> Autoplay (3s)
+        </label>
+
+        <div style="margin-left: auto; display: flex; gap: 8px;">
+          <md-button color="outlined" id="prevBtn">Previous</md-button>
+          <md-button color="filled" id="nextBtn">Next</md-button>
+        </div>
+      </div>
+
+      <div class="carousel-wrapper tall">
+        <md-carousel id="playgroundCarousel" layout="multi-browse" indicators loop>
+          <md-carousel-item interactive headline="Mountain Vista" subhead="Rocky Peaks National Park">
+            <span class="badge-tag">Featured</span>
+            <img src="./images/img1.jpg" alt="Mountain Vista" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Ocean Sunset" subhead="Golden hour at Pacific Coast">
+            <span class="badge-tag">New</span>
+            <img src="./images/img2.jpg" alt="Ocean Sunset" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Forest Trail" subhead="Misty Redwood Sanctuary">
+            <img src="./images/img3.jpg" alt="Forest Trail" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Desert Dunes" subhead="Sahara Twilight Expedition">
+            <img src="./images/img4.jpg" alt="Desert Dunes" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Alpine Valley" subhead="Spring Blooms & Snow Peaks">
+            <img src="./images/img1.jpg" alt="Alpine Valley" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Island Lagoon" subhead="Crystal Blue Waters">
+            <img src="./images/img2.jpg" alt="Island Lagoon" />
+          </md-carousel-item>
+        </md-carousel>
+      </div>
+    </div>
+
+    <!-- 1. Multi-Browse Layout -->
+    <div class="demo-section">
+      <h2 class="section-title">1. Multi-Browse Layout (Default)</h2>
+      <p class="section-desc">
+        Displays items of varying sizes (large, medium, and small peek). Dynamically recalculates item widths as the container resizes.
+      </p>
+
+      <div class="carousel-wrapper">
+        <md-carousel layout="multi-browse" indicators>
+          <md-carousel-item interactive headline="Architecture" subhead="Modern structures">
+            <img src="./images/img1.jpg" alt="Architecture" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Nature" subhead="Wildlife and wilderness">
+            <img src="./images/img2.jpg" alt="Nature" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Travel" subhead="Scenic journeys">
+            <img src="./images/img3.jpg" alt="Travel" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Cuisine" subhead="Culinary arts">
+            <img src="./images/img4.jpg" alt="Cuisine" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Culture" subhead="Heritage and traditions">
+            <img src="./images/img1.jpg" alt="Culture" />
+          </md-carousel-item>
+        </md-carousel>
+      </div>
+    </div>
+
+    <!-- 2. Uncontained Layout with Cards -->
+    <div class="demo-section">
+      <h2 class="section-title">2. Uncontained Layout with Custom Cards</h2>
+      <p class="section-desc">
+        Displays uniform width items scrolling across the container boundary. Excellent for cards, articles, and text-heavy items.
+      </p>
+
+      <div class="carousel-wrapper">
+        <md-carousel layout="uncontained" item-width="300px" indicators>
+          <md-carousel-item type="elevated" interactive>
+            <div class="custom-card">
+              <div>
+                <h3 style="margin-top: 0; margin-bottom: 8px;">Explore Components</h3>
+                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4;">
+                  Discover Material 3 Expressive buttons, pickers, cards, navigation, and carousels.
+                </p>
+              </div>
+              <div style="display: flex; justify-content: flex-end;">
+                <md-button color="tonal">Learn more</md-button>
+              </div>
+            </div>
+          </md-carousel-item>
+
+          <md-carousel-item type="filled" interactive>
+            <div class="custom-card">
+              <div>
+                <h3 style="margin-top: 0; margin-bottom: 8px;">Design Tokens</h3>
+                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4;">
+                  Full support for dynamic color schemes, shape tokens, and typography scales.
+                </p>
+              </div>
+              <div style="display: flex; justify-content: flex-end;">
+                <md-button color="tonal">Customize</md-button>
+              </div>
+            </div>
+          </md-carousel-item>
+
+          <md-carousel-item type="outlined" interactive>
+            <div class="custom-card">
+              <div>
+                <h3 style="margin-top: 0; margin-bottom: 8px;">Web Components</h3>
+                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4;">
+                  Standards-compliant Lit web components with seamless framework compatibility.
+                </p>
+              </div>
+              <div style="display: flex; justify-content: flex-end;">
+                <md-button color="tonal">Get Started</md-button>
+              </div>
+            </div>
+          </md-carousel-item>
+
+          <md-carousel-item type="elevated" interactive>
+            <div class="custom-card">
+              <div>
+                <h3 style="margin-top: 0; margin-bottom: 8px;">Responsive Layouts</h3>
+                <p style="color: var(--md-sys-color-on-surface-variant, #49454f); font-size: 0.9rem; line-height: 1.4;">
+                  Auto-adapting layouts with smooth touch, trackpad, and mouse drag interactions.
+                </p>
+              </div>
+              <div style="display: flex; justify-content: flex-end;">
+                <md-button color="tonal">View Docs</md-button>
+              </div>
+            </div>
+          </md-carousel-item>
+        </md-carousel>
+      </div>
+    </div>
+
+    <!-- 3. Hero Layout (Start-aligned) -->
+    <div class="demo-section">
+      <h2 class="section-title">3. Hero Layout (Start-aligned)</h2>
+      <p class="section-desc">
+        Spotlights one dominant large item with a smaller peek item on the trailing side.
+      </p>
+
+      <div class="carousel-wrapper tall">
+        <md-carousel layout="hero" indicators loop>
+          <md-carousel-item interactive headline="Summer Spotlight Series" subhead="Curated collections from top photographers">
+            <span class="badge-tag">Editor's Pick</span>
+            <img src="./images/img3.jpg" alt="Summer Spotlight" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Pacific Northwest" subhead="Scenic coastal highways & ancient forests">
+            <span class="badge-tag">Popular</span>
+            <img src="./images/img4.jpg" alt="Pacific Northwest" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Urban Horizons" subhead="Modern architectural marvels">
+            <img src="./images/img1.jpg" alt="Urban Horizons" />
+          </md-carousel-item>
+        </md-carousel>
+      </div>
+    </div>
+
+    <!-- 4. Centered Hero Layout -->
+    <div class="demo-section">
+      <h2 class="section-title">4. Centered Hero Layout</h2>
+      <p class="section-desc">
+        Centers one large focal item flanked by peek items on both the left and right edges.
+      </p>
+
+      <div class="carousel-wrapper tall">
+        <md-carousel layout="centered-hero" indicators loop>
+          <md-carousel-item interactive headline="Episode I: Origins" subhead="The Journey Begins">
+            <img src="./images/img2.jpg" alt="Episode 1" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Episode II: Discovery" subhead="Exploring Uncharted Realms">
+            <img src="./images/img3.jpg" alt="Episode 2" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Episode III: Convergence" subhead="The Ultimate Destination">
+            <img src="./images/img4.jpg" alt="Episode 3" />
+          </md-carousel-item>
+          <md-carousel-item interactive headline="Episode IV: Horizon" subhead="Into the Sunrise">
+            <img src="./images/img1.jpg" alt="Episode 4" />
+          </md-carousel-item>
+        </md-carousel>
+      </div>
+    </div>
+
+    <!-- 5. Full-Screen Layout with Autoplay -->
+    <div class="demo-section">
+      <h2 class="section-title">5. Full-Screen Layout with Autoplay (4s)</h2>
+      <p class="section-desc">
+        Edge-to-edge full width slide presentation with pagination and hover-pause autoplay.
+      </p>
+
+      <div class="carousel-wrapper full">
+        <md-carousel layout="full-screen" indicators loop autoplay="4000">
+          <md-carousel-item headline="Design Systems Reimagined" subhead="Building cohesive, accessible experiences across web & mobile">
+            <img src="./images/img1.jpg" alt="Slide 1" />
+          </md-carousel-item>
+          <md-carousel-item headline="Fluid Responsive Components" subhead="Seamlessly scaling from compact smartphones to desktop displays">
+            <img src="./images/img2.jpg" alt="Slide 2" />
+          </md-carousel-item>
+          <md-carousel-item headline="Material 3 Expressive Power" subhead="Modern shapes, dynamic color schemes, and tactile motion">
+            <img src="./images/img4.jpg" alt="Slide 3" />
+          </md-carousel-item>
+        </md-carousel>
+      </div>
+    </div>
+
+    <script>
+      // Interactive playground controls logic
+      const carousel = document.getElementById('playgroundCarousel')
+      const layoutSelect = document.getElementById('layoutSelect')
+      const indicatorsToggle = document.getElementById('indicatorsToggle')
+      const loopToggle = document.getElementById('loopToggle')
+      const autoplayToggle = document.getElementById('autoplayToggle')
+      const prevBtn = document.getElementById('prevBtn')
+      const nextBtn = document.getElementById('nextBtn')
+      const statusSpan = document.getElementById('activeSlideStatus')
+
+      layoutSelect.addEventListener('change', (e) => {
+        carousel.layout = e.target.value
+      })
+
+      indicatorsToggle.addEventListener('change', (e) => {
+        carousel.indicators = e.target.checked
+      })
+
+      loopToggle.addEventListener('change', (e) => {
+        carousel.loop = e.target.checked
+      })
+
+      autoplayToggle.addEventListener('change', (e) => {
+        carousel.autoplay = e.target.checked ? 3000 : 0
+      })
+
+      prevBtn.addEventListener('click', () => carousel.previous())
+      nextBtn.addEventListener('click', () => carousel.next())
+
+      carousel.addEventListener('change', (e) => {
+        const total = carousel.items.length
+        statusSpan.textContent = `Active Slide: ${e.detail.index + 1} / ${total}`
+      })
+    </script>
+  </body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -187,22 +187,22 @@
             </div>
 
             <h3>Progress</h3>
-            <div class="flex g12 aic" style="margin-bottom: 12px; flex-wrap: wrap;">
+            <div class="flex g12 aic" style="margin-bottom: 12px; flex-wrap: wrap">
               <md-progress type="circular" indeterminate shape="flat"></md-progress>
               <md-progress type="circular" value="0.7"></md-progress>
-              <md-progress type="linear" value="0.5" style="width: 200px;"></md-progress>
+              <md-progress type="linear" value="0.5" style="width: 200px"></md-progress>
             </div>
 
             <h4>Wavy Progress Indicators</h4>
-            <div class="flex g12 aic" style="margin-bottom: 24px; flex-wrap: wrap;">
+            <div class="flex g12 aic" style="margin-bottom: 24px; flex-wrap: wrap">
               <md-progress type="circular" indeterminate shape="wavy"></md-progress>
               <md-progress type="circular" value="0.7" shape="wavy"></md-progress>
-              <md-progress type="linear" value="0.5" shape="wavy" style="width: 200px;"></md-progress>
-              <md-progress type="linear" indeterminate shape="wavy" style="width: 200px;"></md-progress>
+              <md-progress type="linear" value="0.5" shape="wavy" style="width: 200px"></md-progress>
+              <md-progress type="linear" indeterminate shape="wavy" style="width: 200px"></md-progress>
             </div>
 
             <h3>Loading Indicator (M3 Expressive)</h3>
-            <div class="flex g12 aic" style="margin-bottom: 24px;">
+            <div class="flex g12 aic" style="margin-bottom: 24px">
               <md-loading></md-loading>
               <md-loading contained></md-loading>
               <md-loading color="var(--md-sys-color-tertiary, #7d5260)"></md-loading>
@@ -210,9 +210,16 @@
               <md-loading size="64" contained></md-loading>
             </div>
 
-            <h3>Carousel (M3 Multi-Browse)</h3>
-            <div style="margin-bottom: 24px;">
-              <md-carousel layout="multi-browse" indicators loop style="height: 220px;">
+            <div class="flex aic" style="justify-content: space-between; align-items: center">
+              <h3 style="margin: 0">Carousel (M3 Multi-Browse)</h3>
+              <a
+                href="./carousel-demo.html"
+                style="display: inline-flex; align-items: center; gap: 4px; font-weight: 500">
+                View Full Carousel Demo <md-icon style="font-size: 18px">arrow_forward</md-icon>
+              </a>
+            </div>
+            <div style="margin-bottom: 24px; margin-top: 12px">
+              <md-carousel layout="multi-browse" indicators loop style="height: 220px">
                 <md-carousel-item interactive headline="Mountain Vista" subhead="National Park">
                   <img src="./images/img1.jpg" alt="Mountain" />
                 </md-carousel-item>

--- a/demo/index.html
+++ b/demo/index.html
@@ -65,6 +65,8 @@
       import 'material/app/bar.js'
       import 'material/indicators/progress.js'
       import 'material/indicators/loading.js'
+      import 'material/carousel/carousel.js'
+      import 'material/carousel/carousel-item.js'
       import './components/expressive-component.js'
     </script>
 
@@ -156,6 +158,7 @@
               Other demo pages:
               <ul>
                 <li><a href="./list-demo.html">List Demo</a></li>
+                <li><a href="./carousel-demo.html">Carousel Demo</a></li>
               </ul>
             </div>
 
@@ -205,6 +208,24 @@
               <md-loading color="var(--md-sys-color-tertiary, #7d5260)"></md-loading>
               <md-loading contained color="white" container-color="var(--md-sys-color-primary, #6750a4)"></md-loading>
               <md-loading size="64" contained></md-loading>
+            </div>
+
+            <h3>Carousel (M3 Multi-Browse)</h3>
+            <div style="margin-bottom: 24px;">
+              <md-carousel layout="multi-browse" indicators loop style="height: 220px;">
+                <md-carousel-item interactive headline="Mountain Vista" subhead="National Park">
+                  <img src="./images/img1.jpg" alt="Mountain" />
+                </md-carousel-item>
+                <md-carousel-item interactive headline="Ocean Coast" subhead="Golden sunset">
+                  <img src="./images/img2.jpg" alt="Ocean" />
+                </md-carousel-item>
+                <md-carousel-item interactive headline="Redwood Forest" subhead="Misty trees">
+                  <img src="./images/img3.jpg" alt="Forest" />
+                </md-carousel-item>
+                <md-carousel-item interactive headline="Desert Valley" subhead="Sahara dunes">
+                  <img src="./images/img4.jpg" alt="Desert" />
+                </md-carousel-item>
+              </md-carousel>
             </div>
 
             <md-snackbar message="Hello World!" open></md-snackbar>


### PR DESCRIPTION
## Description

Implements the **Material 3 Carousel** web component based on the official [Material Design 3 Carousel specification](https://m3.material.io/components/carousel/overview).

### Features
- **`<md-carousel>`**:
  - Supports all 5 M3 layout strategies: `multi-browse` (default dynamic sizing), `uncontained`, `hero`, `centered-hero`, and `full-screen`.
  - Floating previous and next navigation icon buttons with chevron icons and boundary disabling.
  - Pagination indicator dots with active pill styling (`indicators`).
  - Pointer drag gestures (mouse/touch) and native CSS scroll-snapping.
  - Autoplay support with auto-pause on hover/focus and resume (`autoplay="3000"`).
  - Full keyboard navigation (Arrow keys, Home/End) and ARIA accessibility roles.
  - Dynamic responsive sizing with `ResizeObserver`.
- **`<md-carousel-item>`**:
  - Corner shapes (`var(--md-sys-shape-corner-extra-large, 28px)` default), card variants (`filled`, `elevated`, `outlined`), and ripple/focus-ring interactivity.
  - Overflow clipping for images/video and slots for `headline`, `subhead`, `scrim`, and actions.
- **Exports & Documentation**:
  - Exported in `all.js` and `common.js`.
  - Comprehensive documentation in `carousel/README.md`.
- **Demos**:
  - Interactive playground and full showcase in `demo/carousel-demo.html`.
  - Linked and integrated into `demo/index.html`.

### Verification
- Verified in headless Chrome via Playwright across all 5 layouts, button navigation, indicator jumping, and layout switching with 0 console errors.