### PR TITLE
fix(tabs): fix hover and active indicator sizing across tab

### DIFF
--- a/tabs/tab.js
+++ b/tabs/tab.js
@@ -93,24 +93,33 @@ export class Tab extends LitElement {
 
   render() {
     const indicator = html`<div class="indicator"></div>`
-    const content = html`
-      <md-focus-ring part="focus-ring" inward .control=${this}></md-focus-ring>
-      <md-elevation part="elevation"></md-elevation>
-      <md-ripple .control=${this}></md-ripple>
-      <div class="content ${classMap(this.getContentClasses())}" role="presentation">
-        <slot name="icon" @slotchange=${this.handleIconSlotChange}></slot>
-        <slot @slotchange=${this.handleSlotChange}></slot>
-        ${this.fullWidthIndicator ? nothing : indicator}
-      </div>
-      ${this.fullWidthIndicator ? indicator : nothing}
-    `
     return html` <div class="wrapper ${this.type}">
-      ${
-        this.href
-          ? html`<a class="button" href=${this.href} target=${this.target || nothing} tabindex="-1">${content}</a>`
-          : html`<div class="button" role="presentation" @click=${this.handleContentClick}>${content}</div>`
-      }
+      <div class="button" role="presentation" @click=${this.handleContentClick}>
+        <md-focus-ring part="focus-ring" inward .control=${this}></md-focus-ring>
+        <md-elevation part="elevation"></md-elevation>
+        <md-ripple .control=${this}></md-ripple>
+        <div class="content ${classMap(this.getContentClasses())}" role="presentation">
+          <slot name="icon" @slotchange=${this.handleIconSlotChange}></slot>
+          <slot @slotchange=${this.handleSlotChange}></slot>
+          ${this.fullWidthIndicator ? nothing : indicator}
+        </div>
+        ${this.fullWidthIndicator ? indicator : nothing}
+        ${this.href ? this.renderLink() : nothing}
+      </div>
     </div>`
+  }
+
+  renderLink() {
+    const { ariaLabel } = this
+    return html`
+      <a
+        class="link"
+        id="link"
+        href=${this.href}
+        target=${this.target || nothing}
+        tabindex="-1"
+        aria-label=${ariaLabel || nothing}></a>
+    `
   }
   getContentClasses() {
     let cc = {
@@ -145,7 +154,7 @@ export class Tab extends LitElement {
       // Prevent default behavior such as scrolling when pressing spacebar.
       event.preventDefault()
       if (this.href) {
-        const link = this.renderRoot.querySelector('a.button')
+        const link = this.renderRoot.querySelector('a.link')
         link?.click()
       } else {
         this.click()
@@ -153,6 +162,9 @@ export class Tab extends LitElement {
     }
   }
   handleContentClick(event) {
+    if (this.href) {
+      return
+    }
     // Ensure the "click" target is always the tab, and not content, by stopping
     // propagation of content clicks and re-clicking the host.
     event.stopPropagation()
@@ -247,14 +259,13 @@ export class Tab extends LitElement {
       :host([active]) md-focus-ring {
         margin-bottom: calc(var(--_active-indicator-height) + 1px);
       }
-      .button {
-        display: inline-flex;
-        position: relative;
-        align-items: center;
-        justify-content: center;
-        text-decoration: none;
-        color: inherit;
+      .link {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
         outline: none;
+        z-index: 1;
       }
       .button::before {
         background: var(--_container-color);


### PR DESCRIPTION
## Problem
Commit `8fbcf33` added `href` support to tabs by wrapping content with `.button` (`a` or `div`) styled with `display: inline-flex; position: relative;`. This introduced a regression:
1. `position: relative` hijacked the containing block for `<md-ripple>`, `.button::before`, and the full-width `.indicator` from `:host` to `.button`.
2. `display: inline-flex` caused `.button` to shrink-wrap around only the text/icon contents, making the hover background and secondary indicator show only on the text area instead of the whole tab.

## Solution
- Removed `.button { display: inline-flex; position: relative; ... }` so `.button` remains `position: static` (as originally designed), restoring `:host` as the containing block.
- Adopted the library-wide `.link` overlay pattern (`nav/item.js`, `nav/tab.js`, `buttons/fab.js`):
  - Render an absolutely-positioned `<a class="link" id="link" ...></a>` covering the full tab when `href` is present.
- Updated `handleContentClick` to return early when `href` is present so link navigation is not interrupted.
- Updated `handleKeydown` to trigger `a.link` on Enter or Space.