### PR TITLE
feat(buttons): align connected button groups with Material 3 spec

### DIFF
--- a/buttons/README.md
+++ b/buttons/README.md
@@ -49,15 +49,22 @@ Standard Button Group:
 Connected Button Group:
 
 ```html
-<md-button-group connected aria-label="View options">
-  <md-button color="outlined">One</md-button>
-  <md-button color="outlined">Two</md-button>
-  <md-button color="outlined">Three</md-button>
+<!-- Single-select connected button group (Material 3 Expressive) -->
+<md-button-group connected aria-label="Folders">
+  <md-button color="tonal" selected>My files</md-button>
+  <md-button color="tonal">Shared</md-button>
+  <md-button color="tonal">Computers</md-button>
+</md-button-group>
+
+<!-- Connected button group with checkmark on selected button -->
+<md-button-group connected checkmark aria-label="Select size">
+  <md-button color="tonal" selected>8oz</md-button>
+  <md-button color="tonal">12oz</md-button>
+  <md-button color="tonal">16oz</md-button>
 </md-button-group>
 ```
 
-> **Accessibility**: Provide an `aria-label` attribute on `<md-button-group>` to identify the group's purpose to assistive technologies.
-> The `connected` variant is primarily intended for use with `outlined` buttons so borders overlap seamlessly per the Material 3 specification.
+> **Material 3 Expressive Specification**: Connected button groups replace the baseline segmented button. They feature 2px gap, fully round outer corners, and inner corner radii (8px for small/medium, 4px for XS, 16px for L, 20px for XL), with single-select or multi-select toggle coordination. Provide an `aria-label` attribute on `<md-button-group>` for accessibility.
 
 ## Floating Action Button - FAB
 

--- a/buttons/button-group.js
+++ b/buttons/button-group.js
@@ -1,56 +1,127 @@
 import { html, LitElement, css } from 'lit'
 
+/**
+ * A Material 3 Button Group layout component.
+ *
+ * Supports standard (8px gap) and connected (2px gap, merged inner radii, single/multi-select) variants.
+ *
+ * https://m3.material.io/components/button-groups/overview
+ *
+ * @fires change {CustomEvent<{button: Button, selected: boolean, value: string|string[], selectedIndex: number}>}
+ * Dispatched when the selection changes within the button group.
+ */
 export class ButtonGroup extends LitElement {
   static styles = css`
     :host {
       display: inline-flex;
       flex-direction: row;
       vertical-align: middle;
+      align-items: center;
     }
 
-    /* Standard group adds gap between buttons */
+    /* Standard group adds 8px gap between buttons */
     :host(:not([connected])) {
       gap: 8px; /* M3 standard button group gap */
     }
 
-    /* Target all buttons except the first one */
-    :host([connected]) ::slotted([group-position='middle']),
-    :host([connected]) ::slotted([group-position='last']),
-    :host([connected]) ::slotted(*:not(:first-child):not([group-position='first'])) {
-      /* Target variant-specific variables explicitly */
-      --md-button-container-shape-start-start: 0;
-      --md-button-container-shape-end-start: 0;
-      --md-filled-tonal-button-container-shape-start-start: 0;
-      --md-filled-tonal-button-container-shape-end-start: 0;
-      --md-elevated-button-container-shape-start-start: 0;
-      --md-elevated-button-container-shape-end-start: 0;
-      --md-outlined-button-container-shape-start-start: 0;
-      --md-outlined-button-container-shape-end-start: 0;
-      --md-icon-button-container-shape-start-start: 0;
-      --md-icon-button-container-shape-end-start: 0;
-
-      /* Overlap borders */
-      margin-inline-start: -1px;
+    /* Connected group adds 2px gap per M3 spec */
+    :host([connected]) {
+      gap: var(--md-button-group-connected-gap, 2px);
+      --_inner-radius: 8px;
     }
 
-    /* Target all buttons except the last one */
-    :host([connected]) ::slotted([group-position='middle']),
-    :host([connected]) ::slotted([group-position='first']),
-    :host([connected]) ::slotted(*:not(:last-child):not([group-position='last'])) {
-      /* Target variant-specific variables explicitly */
-      --md-button-container-shape-start-end: 0;
-      --md-button-container-shape-end-end: 0;
-      --md-filled-tonal-button-container-shape-start-end: 0;
-      --md-filled-tonal-button-container-shape-end-end: 0;
-      --md-elevated-button-container-shape-start-end: 0;
-      --md-elevated-button-container-shape-end-end: 0;
-      --md-outlined-button-container-shape-start-end: 0;
-      --md-outlined-button-container-shape-end-end: 0;
-      --md-icon-button-container-shape-start-end: 0;
-      --md-icon-button-container-shape-end-end: 0;
+    /* Connected buttons expand to share container width equally */
+    :host([connected]) ::slotted(*) {
+      flex: 1 1 0%;
     }
 
-    /* Ensure the active/hovered/focused button is on top to show full border */
+    /* Inner corner sizes by button group size */
+    :host([connected][size='extra-small']) {
+      --_inner-radius: 4px;
+    }
+    :host([connected][size='small']) {
+      --_inner-radius: 8px;
+    }
+    :host([connected][size='medium']) {
+      --_inner-radius: 8px;
+    }
+    :host([connected][size='large']) {
+      --_inner-radius: 16px;
+    }
+    :host([connected][size='extra-large']) {
+      --_inner-radius: 20px;
+    }
+
+    /* Also support child size attributes */
+    :host([connected]) ::slotted([size='extra-small']) {
+      --_inner-radius: 4px;
+    }
+    :host([connected]) ::slotted([size='small']) {
+      --_inner-radius: 8px;
+    }
+    :host([connected]) ::slotted([size='medium']) {
+      --_inner-radius: 8px;
+    }
+    :host([connected]) ::slotted([size='large']) {
+      --_inner-radius: 16px;
+    }
+    :host([connected]) ::slotted([size='extra-large']) {
+      --_inner-radius: 20px;
+    }
+
+    /* First button: inner (end) corners rounded to _inner-radius, start corners fully round */
+    :host([connected]) ::slotted([group-position='first']) {
+      --md-button-container-shape-start-end: var(--_inner-radius, 8px);
+      --md-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-filled-tonal-button-container-shape-start-end: var(--_inner-radius, 8px);
+      --md-filled-tonal-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-elevated-button-container-shape-start-end: var(--_inner-radius, 8px);
+      --md-elevated-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-outlined-button-container-shape-start-end: var(--_inner-radius, 8px);
+      --md-outlined-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-icon-button-container-shape-start-end: var(--_inner-radius, 8px);
+      --md-icon-button-container-shape-end-end: var(--_inner-radius, 8px);
+    }
+
+    /* Middle buttons: all 4 corners rounded to _inner-radius */
+    :host([connected]) ::slotted([group-position='middle']) {
+      --md-button-container-shape-start-start: var(--_inner-radius, 8px);
+      --md-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-button-container-shape-start-end: var(--_inner-radius, 8px);
+      --md-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-filled-tonal-button-container-shape-start-start: var(--_inner-radius, 8px);
+      --md-filled-tonal-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-filled-tonal-button-container-shape-start-end: var(--_inner-radius, 8px);
+      --md-filled-tonal-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-elevated-button-container-shape-start-start: var(--_inner-radius, 8px);
+      --md-elevated-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-elevated-button-container-shape-start-end: var(--_inner-radius, 8px);
+      --md-elevated-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-outlined-button-container-shape-start-start: var(--_inner-radius, 8px);
+      --md-outlined-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-outlined-button-container-shape-start-end: var(--_inner-radius, 8px);
+      --md-outlined-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-icon-button-container-shape-start-start: var(--_inner-radius, 8px);
+      --md-icon-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-icon-button-container-shape-start-end: var(--_inner-radius, 8px);
+      --md-icon-button-container-shape-end-end: var(--_inner-radius, 8px);
+    }
+
+    /* Last button: inner (start) corners rounded to _inner-radius, end corners fully round */
+    :host([connected]) ::slotted([group-position='last']) {
+      --md-button-container-shape-start-start: var(--_inner-radius, 8px);
+      --md-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-filled-tonal-button-container-shape-start-start: var(--_inner-radius, 8px);
+      --md-filled-tonal-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-elevated-button-container-shape-start-start: var(--_inner-radius, 8px);
+      --md-elevated-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-outlined-button-container-shape-start-start: var(--_inner-radius, 8px);
+      --md-outlined-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-icon-button-container-shape-start-start: var(--_inner-radius, 8px);
+      --md-icon-button-container-shape-end-start: var(--_inner-radius, 8px);
+    }
+
+    /* Ensure active/hovered/focused button is above adjacent buttons */
     :host([connected]) ::slotted(*:hover),
     :host([connected]) ::slotted(*:focus-within),
     :host([connected]) ::slotted(*:active) {
@@ -58,7 +129,7 @@ export class ButtonGroup extends LitElement {
       position: relative;
     }
 
-    /* Selected state needs to be above unselected for connected groups */
+    /* Selected state */
     :host([connected]) ::slotted([selected]) {
       z-index: 1;
       position: relative;
@@ -67,14 +138,25 @@ export class ButtonGroup extends LitElement {
 
   static properties = {
     connected: { type: Boolean, reflect: true },
+    multiselect: { type: Boolean, reflect: true },
+    selectionRequired: { type: Boolean, attribute: 'selection-required', reflect: true },
+    checkmark: { type: Boolean, reflect: true },
+    size: { type: String, reflect: true },
   }
 
   constructor() {
     super()
     this.connected = false
+    this.multiselect = false
+    this.selectionRequired = true
+    this.checkmark = false
+    this.size = ''
+
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'group')
     }
+
+    this.addEventListener('click', this.handleClick.bind(this))
   }
 
   connectedCallback() {
@@ -91,7 +173,7 @@ export class ButtonGroup extends LitElement {
 
   updated(changedProperties) {
     super.updated(changedProperties)
-    if (changedProperties.has('connected')) {
+    if (changedProperties.has('connected') || changedProperties.has('checkmark') || changedProperties.has('size')) {
       this.updateConnectedPositions()
     }
   }
@@ -106,13 +188,64 @@ export class ButtonGroup extends LitElement {
     return elements.filter((el) => !['STYLE', 'SCRIPT', 'TEMPLATE'].includes(el.tagName))
   }
 
+  get selectedButtons() {
+    return this.buttons.filter((b) => b.selected)
+  }
+
+  get selectedIndex() {
+    return this.buttons.findIndex((b) => b.selected)
+  }
+
+  set selectedIndex(index) {
+    this.buttons.forEach((b, i) => {
+      b.selected = i === index
+    })
+  }
+
+  get value() {
+    if (this.multiselect) {
+      return this.selectedButtons.map((b) => b.value || b.textContent.trim())
+    }
+    const selected = this.selectedButtons[0]
+    return selected ? selected.value || selected.textContent.trim() : ''
+  }
+
+  set value(val) {
+    if (this.multiselect && Array.isArray(val)) {
+      this.buttons.forEach((b) => {
+        const v = b.value || b.textContent.trim()
+        b.selected = val.includes(v)
+      })
+    } else {
+      this.buttons.forEach((b) => {
+        const v = b.value || b.textContent.trim()
+        b.selected = v === val
+      })
+    }
+  }
+
   updateConnectedPositions() {
     const buttons = this.buttons
     const count = buttons.length
 
     buttons.forEach((button, index) => {
+      // Propagate checkmark and toggle settings
+      if (this.checkmark && !button.hasAttribute('checkmark')) {
+        button.checkmark = true
+      }
+      if (this.connected && !button.toggle) {
+        button.toggle = true
+      }
+      if (this.size && !button.size) {
+        button.size = this.size
+      }
+
       if (!this.connected || count <= 1) {
-        button.removeAttribute('group-position')
+        if (count === 1) {
+          button.setAttribute('group-position', 'single')
+        } else {
+          button.removeAttribute('group-position')
+        }
       } else if (index === 0) {
         button.setAttribute('group-position', 'first')
       } else if (index === count - 1) {
@@ -121,6 +254,51 @@ export class ButtonGroup extends LitElement {
         button.setAttribute('group-position', 'middle')
       }
     })
+  }
+
+  handleClick(event) {
+    const path = event.composedPath()
+    const button = this.buttons.find((btn) => path.includes(btn))
+    if (!button || button.disabled) return
+
+    const isToggle = this.connected || button.toggle
+    if (!isToggle) return
+
+    if (this.multiselect) {
+      if (this.selectionRequired && !button.selected && this.selectedButtons.length === 0) {
+        // Button was deselected by button's handleClick, restore if selectionRequired
+        button.selected = true
+        return
+      }
+    } else {
+      // Single select:
+      if (this.selectionRequired && !button.selected && this.selectedButtons.length === 0) {
+        // User clicked the already selected button (which toggled itself off), re-select it
+        button.selected = true
+        return
+      }
+
+      // Deselect other buttons
+      this.buttons.forEach((b) => {
+        if (b !== button) {
+          b.selected = false
+        }
+      })
+      button.selected = true
+    }
+
+    this.dispatchEvent(
+      new CustomEvent('change', {
+        detail: {
+          button,
+          selected: button.selected,
+          value: this.value,
+          selectedIndex: this.selectedIndex,
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    )
   }
 
   render() {

--- a/buttons/button-group.js
+++ b/buttons/button-group.js
@@ -156,7 +156,7 @@ export class ButtonGroup extends LitElement {
       this.setAttribute('role', 'group')
     }
 
-    this.addEventListener('click', this.handleClick.bind(this))
+    this.handleClick = this.handleClick.bind(this)
   }
 
   connectedCallback() {
@@ -164,6 +164,12 @@ export class ButtonGroup extends LitElement {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'group')
     }
+    this.addEventListener('click', this.handleClick)
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback()
+    this.removeEventListener('click', this.handleClick)
   }
 
   firstUpdated(changedProperties) {
@@ -278,13 +284,14 @@ export class ButtonGroup extends LitElement {
         return
       }
 
+      const shouldBeSelected = !this.selectionRequired && !button.selected ? false : true
       // Deselect other buttons
       this.buttons.forEach((b) => {
         if (b !== button) {
           b.selected = false
         }
       })
-      button.selected = true
+      button.selected = shouldBeSelected
     }
 
     this.dispatchEvent(

--- a/buttons/button.js
+++ b/buttons/button.js
@@ -34,6 +34,7 @@ export class Button extends LitElement {
     type: { type: String },
     selected: { type: Boolean, reflect: true },
     toggle: { type: Boolean, reflect: true },
+    checkmark: { type: Boolean, reflect: true },
   }
 
   get name() {
@@ -107,6 +108,10 @@ export class Button extends LitElement {
      * Set to turn this into a toggle button.
      */
     this.toggle = false
+    /**
+     * Whether to show a checkmark icon when selected.
+     */
+    this.checkmark = false
 
     this.handleActivationClick = (event) => {
       if (!isActivationClick(event) || !this.buttonElement) {
@@ -211,9 +216,15 @@ export class Button extends LitElement {
   }
   renderContent() {
     const icon = html`<slot name="icon" @slotchange="${this.handleSlotChange}"></slot>`
+    const checkmark =
+      this.checkmark && this.selected
+        ? html`<svg class="checkmark" viewBox="0 0 18 18" aria-hidden="true">
+            <path d="M6.75 12.127L3.623 9l-1.06 1.057L6.75 14.25l9-9-1.057-1.06z"></path>
+          </svg>`
+        : nothing
     return html`
       <span class="touch"></span>
-      ${this.trailingIcon ? nothing : icon}
+      ${this.trailingIcon ? nothing : checkmark || icon}
       <span class="label"><slot></slot></span>
       ${this.trailingIcon ? icon : nothing}
     `
@@ -1013,6 +1024,33 @@ export class Button extends LitElement {
         opacity: var(--_disabled-icon-opacity);
       }
 
+      .checkmark {
+        writing-mode: horizontal-tb;
+        fill: currentColor;
+        flex-shrink: 0;
+        color: var(--_icon-color);
+        font-size: var(--_icon-size, 18px);
+        inline-size: var(--_icon-size, 18px);
+        block-size: var(--_icon-size, 18px);
+      }
+
+      :host(:hover) .checkmark {
+        color: var(--_hover-icon-color);
+      }
+
+      :host(:focus-within) .checkmark {
+        color: var(--_focus-icon-color);
+      }
+
+      :host(:active) .checkmark {
+        color: var(--_pressed-icon-color);
+      }
+
+      :host([disabled]) .checkmark {
+        color: var(--_disabled-icon-color);
+        opacity: var(--_disabled-icon-opacity);
+      }
+
       .touch {
         position: absolute;
         top: 50%;
@@ -1117,6 +1155,21 @@ export class Button extends LitElement {
       :host([pressed][size='extra-large']),
       :host([selected][size='extra-large']) {
         border-radius: 16px;
+      }
+
+      :host([group-position]) {
+        border-start-start-radius: var(--_container-shape-start-start);
+        border-start-end-radius: var(--_container-shape-start-end);
+        border-end-start-radius: var(--_container-shape-end-start);
+        border-end-end-radius: var(--_container-shape-end-end);
+        border-radius: unset;
+      }
+      :host([group-position][selected]) {
+        border-start-start-radius: var(--_container-shape-start-start);
+        border-start-end-radius: var(--_container-shape-start-end);
+        border-end-start-radius: var(--_container-shape-end-start);
+        border-end-end-radius: var(--_container-shape-end-end);
+        border-radius: unset;
       }
     `,
   ]

--- a/buttons/button.js
+++ b/buttons/button.js
@@ -1157,13 +1157,7 @@ export class Button extends LitElement {
         border-radius: 16px;
       }
 
-      :host([group-position]) {
-        border-start-start-radius: var(--_container-shape-start-start);
-        border-start-end-radius: var(--_container-shape-start-end);
-        border-end-start-radius: var(--_container-shape-end-start);
-        border-end-end-radius: var(--_container-shape-end-end);
-        border-radius: unset;
-      }
+      :host([group-position]),
       :host([group-position][selected]) {
         border-start-start-radius: var(--_container-shape-start-start);
         border-start-end-radius: var(--_container-shape-start-end);

--- a/demo/components/expressive-component.js
+++ b/demo/components/expressive-component.js
@@ -280,13 +280,32 @@ class ExpressiveComponent extends LitElement {
             </md-button-group>
           </div>
 
-          <h4>Connected</h4>
-          <div class="flexw g12 aic">
-            <md-button-group connected aria-label="Connected outlined group">
-              <md-button color="outlined" toggle>Day</md-button>
-              <md-button color="outlined" toggle selected>Week</md-button>
-              <md-button color="outlined" toggle>Month</md-button>
-              <md-button color="outlined" toggle>Year</md-button>
+          <h4>Folders (Connected Tonal)</h4>
+          <div style="max-width: 420px;">
+            <md-button-group connected aria-label="Folders" style="width: 100%;">
+              <md-button color="tonal" selected>My files</md-button>
+              <md-button color="tonal">Shared</md-button>
+              <md-button color="tonal">Computers</md-button>
+            </md-button-group>
+          </div>
+
+          <h4>Select size (Connected with Checkmark)</h4>
+          <div style="max-width: 360px;" class="flex col g12">
+            <md-button-group connected checkmark aria-label="Select size" style="width: 100%;">
+              <md-button color="tonal" selected>8oz</md-button>
+              <md-button color="tonal">12oz</md-button>
+              <md-button color="tonal">16oz</md-button>
+            </md-button-group>
+            <md-button style="width: 100%;">Add to cart</md-button>
+          </div>
+
+          <h4>View (Connected Outlined)</h4>
+          <div style="max-width: 420px;">
+            <md-button-group connected aria-label="View options" style="width: 100%;">
+              <md-button color="outlined">Day</md-button>
+              <md-button color="outlined" selected>Week</md-button>
+              <md-button color="outlined">Month</md-button>
+              <md-button color="outlined">Year</md-button>
             </md-button-group>
           </div>
         </div>


### PR DESCRIPTION
Aligns the connected button group layout and behavior with the official [Material 3 Button Groups specification](https://m3.material.io/components/button-groups/overview).

### Changes
- **Layout & Spacing**: Replaced 0px overlapping border layout with the M3-specified `gap: 2px` (`--md-button-group-connected-gap`).
- **Corner Radii**: Added M3 inner corner radii (8px for small/medium, 4px for XS, 16px for L, 20px for XL) and fully rounded outer ends (9999px pill).
- **Width Distribution**: Slotted buttons in connected groups share container width equally (`flex: 1 1 0%`).
- **Selection Coordination**: Added single-select and multi-select handling with `selection-required` support to `<md-button-group>`, including `value`, `selectedIndex`, `selectedButtons` properties, and bubbling `change` event.
- **Selection Checkmark**: Added `checkmark` support to `<md-button>` and `<md-button-group checkmark>` to render an SVG checkmark when selected (e.g. `[ ✓ 8oz ] [ 12oz ] [ 16oz ]`).
- **Demo & Docs**: Added the spec's "Folders" and "Select size" examples to `demo/components/expressive-component.js` and updated `buttons/README.md`.

Closes #85