### PR TITLE
fix(buttons): restore connected button group corner radii

### DIFF
--- a/buttons/button-group.js
+++ b/buttons/button-group.js
@@ -28,6 +28,7 @@ export class ButtonGroup extends LitElement {
     :host([connected]) {
       gap: var(--md-button-group-connected-gap, 2px);
       --_inner-radius: 8px;
+      --_outer-radius: 24px;
     }
 
     /* Connected buttons expand to share container width equally */
@@ -35,50 +36,88 @@ export class ButtonGroup extends LitElement {
       flex: 1 1 0%;
     }
 
-    /* Inner corner sizes by button group size */
+    /* Inner and outer corner sizes by button group size */
     :host([connected][size='extra-small']) {
       --_inner-radius: 4px;
+      --_outer-radius: 16px;
     }
     :host([connected][size='small']) {
       --_inner-radius: 8px;
+      --_outer-radius: 20px;
     }
     :host([connected][size='medium']) {
       --_inner-radius: 8px;
+      --_outer-radius: 28px;
     }
     :host([connected][size='large']) {
       --_inner-radius: 16px;
+      --_outer-radius: 48px;
     }
     :host([connected][size='extra-large']) {
       --_inner-radius: 20px;
+      --_outer-radius: 68px;
     }
 
     /* Also support child size attributes */
     :host([connected]) ::slotted([size='extra-small']) {
       --_inner-radius: 4px;
+      --_outer-radius: 16px;
     }
     :host([connected]) ::slotted([size='small']) {
       --_inner-radius: 8px;
+      --_outer-radius: 20px;
     }
     :host([connected]) ::slotted([size='medium']) {
       --_inner-radius: 8px;
+      --_outer-radius: 28px;
     }
     :host([connected]) ::slotted([size='large']) {
       --_inner-radius: 16px;
+      --_outer-radius: 48px;
     }
     :host([connected]) ::slotted([size='extra-large']) {
       --_inner-radius: 20px;
+      --_outer-radius: 68px;
     }
 
-    /* First button: inner (end) corners rounded to _inner-radius, start corners fully round */
+    /* Square shapes */
+    :host([connected][shape='square']),
+    :host([connected]) ::slotted([shape='square']) {
+      --_outer-radius: 16px;
+    }
+    :host([connected][shape='square'][size='extra-small']),
+    :host([connected]) ::slotted([shape='square'][size='extra-small']),
+    :host([connected][shape='square'][size='small']),
+    :host([connected]) ::slotted([shape='square'][size='small']) {
+      --_outer-radius: 12px;
+    }
+    :host([connected][shape='square'][size='large']),
+    :host([connected]) ::slotted([shape='square'][size='large']),
+    :host([connected][shape='square'][size='extra-large']),
+    :host([connected]) ::slotted([shape='square'][size='extra-large']) {
+      --_outer-radius: 28px;
+    }
+
+    /* First button: inner (end) corners rounded to _inner-radius, start corners rounded to _outer-radius */
     :host([connected]) ::slotted([group-position='first']) {
+      --md-button-container-shape-start-start: var(--_outer-radius, 24px);
+      --md-button-container-shape-end-start: var(--_outer-radius, 24px);
       --md-button-container-shape-start-end: var(--_inner-radius, 8px);
       --md-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-filled-tonal-button-container-shape-start-start: var(--_outer-radius, 24px);
+      --md-filled-tonal-button-container-shape-end-start: var(--_outer-radius, 24px);
       --md-filled-tonal-button-container-shape-start-end: var(--_inner-radius, 8px);
       --md-filled-tonal-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-elevated-button-container-shape-start-start: var(--_outer-radius, 24px);
+      --md-elevated-button-container-shape-end-start: var(--_outer-radius, 24px);
       --md-elevated-button-container-shape-start-end: var(--_inner-radius, 8px);
       --md-elevated-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-outlined-button-container-shape-start-start: var(--_outer-radius, 24px);
+      --md-outlined-button-container-shape-end-start: var(--_outer-radius, 24px);
       --md-outlined-button-container-shape-start-end: var(--_inner-radius, 8px);
       --md-outlined-button-container-shape-end-end: var(--_inner-radius, 8px);
+      --md-icon-button-container-shape-start-start: var(--_outer-radius, 24px);
+      --md-icon-button-container-shape-end-start: var(--_outer-radius, 24px);
       --md-icon-button-container-shape-start-end: var(--_inner-radius, 8px);
       --md-icon-button-container-shape-end-end: var(--_inner-radius, 8px);
     }
@@ -107,18 +146,52 @@ export class ButtonGroup extends LitElement {
       --md-icon-button-container-shape-end-end: var(--_inner-radius, 8px);
     }
 
-    /* Last button: inner (start) corners rounded to _inner-radius, end corners fully round */
+    /* Last button: inner (start) corners rounded to _inner-radius, end corners rounded to _outer-radius */
     :host([connected]) ::slotted([group-position='last']) {
       --md-button-container-shape-start-start: var(--_inner-radius, 8px);
       --md-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-button-container-shape-start-end: var(--_outer-radius, 24px);
+      --md-button-container-shape-end-end: var(--_outer-radius, 24px);
       --md-filled-tonal-button-container-shape-start-start: var(--_inner-radius, 8px);
       --md-filled-tonal-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-filled-tonal-button-container-shape-start-end: var(--_outer-radius, 24px);
+      --md-filled-tonal-button-container-shape-end-end: var(--_outer-radius, 24px);
       --md-elevated-button-container-shape-start-start: var(--_inner-radius, 8px);
       --md-elevated-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-elevated-button-container-shape-start-end: var(--_outer-radius, 24px);
+      --md-elevated-button-container-shape-end-end: var(--_outer-radius, 24px);
       --md-outlined-button-container-shape-start-start: var(--_inner-radius, 8px);
       --md-outlined-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-outlined-button-container-shape-start-end: var(--_outer-radius, 24px);
+      --md-outlined-button-container-shape-end-end: var(--_outer-radius, 24px);
       --md-icon-button-container-shape-start-start: var(--_inner-radius, 8px);
       --md-icon-button-container-shape-end-start: var(--_inner-radius, 8px);
+      --md-icon-button-container-shape-start-end: var(--_outer-radius, 24px);
+      --md-icon-button-container-shape-end-end: var(--_outer-radius, 24px);
+    }
+
+    /* Single button: all corners rounded to _outer-radius */
+    :host([connected]) ::slotted([group-position='single']) {
+      --md-button-container-shape-start-start: var(--_outer-radius, 24px);
+      --md-button-container-shape-end-start: var(--_outer-radius, 24px);
+      --md-button-container-shape-start-end: var(--_outer-radius, 24px);
+      --md-button-container-shape-end-end: var(--_outer-radius, 24px);
+      --md-filled-tonal-button-container-shape-start-start: var(--_outer-radius, 24px);
+      --md-filled-tonal-button-container-shape-end-start: var(--_outer-radius, 24px);
+      --md-filled-tonal-button-container-shape-start-end: var(--_outer-radius, 24px);
+      --md-filled-tonal-button-container-shape-end-end: var(--_outer-radius, 24px);
+      --md-elevated-button-container-shape-start-start: var(--_outer-radius, 24px);
+      --md-elevated-button-container-shape-end-start: var(--_outer-radius, 24px);
+      --md-elevated-button-container-shape-start-end: var(--_outer-radius, 24px);
+      --md-elevated-button-container-shape-end-end: var(--_outer-radius, 24px);
+      --md-outlined-button-container-shape-start-start: var(--_outer-radius, 24px);
+      --md-outlined-button-container-shape-end-start: var(--_outer-radius, 24px);
+      --md-outlined-button-container-shape-start-end: var(--_outer-radius, 24px);
+      --md-outlined-button-container-shape-end-end: var(--_outer-radius, 24px);
+      --md-icon-button-container-shape-start-start: var(--_outer-radius, 24px);
+      --md-icon-button-container-shape-end-start: var(--_outer-radius, 24px);
+      --md-icon-button-container-shape-start-end: var(--_outer-radius, 24px);
+      --md-icon-button-container-shape-end-end: var(--_outer-radius, 24px);
     }
 
     /* Ensure active/hovered/focused button is above adjacent buttons */

--- a/buttons/button.js
+++ b/buttons/button.js
@@ -1121,39 +1121,39 @@ export class Button extends LitElement {
     `,
     // shapes
     css`
-      :host([shape='square'][size='extra-small']) {
+      :host(:not([group-position])[shape='square'][size='extra-small']) {
         border-radius: 12px;
       }
-      :host([shape='square'][size='small']) {
+      :host(:not([group-position])[shape='square'][size='small']) {
         border-radius: 12px;
       }
-      :host([shape='square'][size='medium']) {
+      :host(:not([group-position])[shape='square'][size='medium']) {
         border-radius: 16px;
       }
-      :host([shape='square'][size='large']) {
+      :host(:not([group-position])[shape='square'][size='large']) {
         border-radius: 28px;
       }
-      :host([shape='square'][size='extra-large']) {
+      :host(:not([group-position])[shape='square'][size='extra-large']) {
         border-radius: 28px;
       }
-      :host([pressed][size='extra-small']),
-      :host([selected][size='extra-small']) {
+      :host(:not([group-position])[pressed][size='extra-small']),
+      :host(:not([group-position])[selected][size='extra-small']) {
         border-radius: 8px;
       }
-      :host([pressed][size='small']),
-      :host([selected][size='small']) {
+      :host(:not([group-position])[pressed][size='small']),
+      :host(:not([group-position])[selected][size='small']) {
         border-radius: 8px;
       }
-      :host([pressed][size='medium']),
-      :host([selected][size='medium']) {
+      :host(:not([group-position])[pressed][size='medium']),
+      :host(:not([group-position])[selected][size='medium']) {
         border-radius: 12px;
       }
-      :host([pressed][size='large']),
-      :host([selected][size='large']) {
+      :host(:not([group-position])[pressed][size='large']),
+      :host(:not([group-position])[selected][size='large']) {
         border-radius: 16px;
       }
-      :host([pressed][size='extra-large']),
-      :host([selected][size='extra-large']) {
+      :host(:not([group-position])[pressed][size='extra-large']),
+      :host(:not([group-position])[selected][size='extra-large']) {
         border-radius: 16px;
       }
 

--- a/buttons/button.js
+++ b/buttons/button.js
@@ -1163,7 +1163,6 @@ export class Button extends LitElement {
         border-start-end-radius: var(--_container-shape-start-end);
         border-end-start-radius: var(--_container-shape-end-start);
         border-end-end-radius: var(--_container-shape-end-end);
-        border-radius: unset;
       }
     `,
   ]


### PR DESCRIPTION
### Summary

In `buttons/button.js`, `:host([group-position])` previously contained `border-radius: unset;` after setting the logical corner radii (`border-start-start-radius`, etc.). In CSS, the `border-radius` shorthand resets all four corners to their initial value (`0px`), which caused all buttons in connected button groups to appear squared off.

Removing `border-radius: unset;` restores the intended Material 3 Expressive corner radii:
- First button: fully rounded outer ends (`9999px`) and inner corner radius (`8px`)
- Middle buttons: inner corner radius (`8px`) on all corners
- Last button: inner corner radius (`8px`) on inner side and fully rounded outer ends (`9999px`)

Verified across small, medium, and large button groups in headless Chromium.