### PR TITLE
docs: update README with component list and new jsDelivr badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   alt="A collection of Material web components"
   style="border-radius: 32px">
 
-[![jsDelivr hits (npm)](https://img.shields.io/jsdelivr/gh/material-esm/material)](https://www.jsdelivr.com/package/gh/material-esm/material?tab=stats)
+[![](https://data.jsdelivr.com/v1/package/gh/material-esm/material/badge)](https://www.jsdelivr.com/package/gh/material-esm/material)
 
 `material` is a library of
 [web components](https://developer.mozilla.org/en-US/docs/Web/Web_Components)
@@ -29,9 +29,32 @@ To start using it, see [this topic](https://github.com/orgs/material-esm/discuss
 
 ## Documentation
 
-All the documentation here still applies: https://material-web.dev/
+See the README in each component's directory for how to use them:
 
-And we are adding README's in this repository for the new components that aren't in those docs.
+- [App Bar](app/README.md)
+- [Badge](badge/README.md)
+- [Buttons](buttons/README.md)
+- [Card](card/README.md)
+- [Carousel](carousel/README.md)
+- [Checkbox](checkbox/README.md)
+- [Chips](chips/README.md)
+- [Dialog](dialog/README.md)
+- [Divider](divider/README.md)
+- [Icon](icon/README.md)
+- [Indicators](indicators/README.md)
+- [List](list/README.md)
+- [Menu](menu/README.md)
+- [Navigation](nav/README.md)
+- [Pickers](pickers/README.md)
+- [Radio](radio/README.md)
+- [Search](search/README.md)
+- [Select](select/README.md)
+- [Slider](slider/README.md)
+- [Snackbar](snackbar/README.md)
+- [Switch](switch/README.md)
+- [Tabs](tabs/README.md)
+- [Text Field](text/README.md)
+- [Tooltip](tooltip/README.md)
 
 ## Quick start
 

--- a/badge/README.md
+++ b/badge/README.md
@@ -1,0 +1,27 @@
+# Badge
+
+[Material Design 3 Badges](https://m3.material.io/components/badges/overview).
+
+Badges draw attention to an element and can display notifications, status, or small counts.
+
+## Import
+
+```js
+import 'material/badge/badge.js'
+```
+
+## Usage
+
+```html
+<!-- Dot badge -->
+<div style="position: relative; display: inline-block;">
+  <md-icon>notifications</md-icon>
+  <md-badge></md-badge>
+</div>
+
+<!-- Badge with numeric value -->
+<div style="position: relative; display: inline-block;">
+  <md-icon>shopping_cart</md-icon>
+  <md-badge value="3"></md-badge>
+</div>
+```

--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -1,0 +1,27 @@
+# Checkbox
+
+[Material Design 3 Checkbox](https://m3.material.io/components/checkbox/overview).
+
+## Import
+
+```js
+import 'material/checkbox/checkbox.js'
+```
+
+## Usage
+
+```html
+<md-checkbox></md-checkbox>
+
+<!-- Checked by default -->
+<md-checkbox checked></md-checkbox>
+
+<!-- Indeterminate state -->
+<md-checkbox indeterminate></md-checkbox>
+
+<!-- Disabled -->
+<md-checkbox disabled></md-checkbox>
+
+<!-- With form attributes -->
+<md-checkbox name="agree" value="yes" required></md-checkbox>
+```

--- a/icon/README.md
+++ b/icon/README.md
@@ -1,0 +1,36 @@
+# Icon
+
+[Material Design 3 Icons](https://m3.material.io/styles/icons/overview).
+
+Icons display symbols from Google Material Symbols or slotted SVGs.
+
+## Import
+
+```js
+import 'material/icon/icon.js'
+```
+
+Ensure you include the Material Symbols font in your HTML:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" />
+```
+
+## Usage
+
+```html
+<!-- Using Material Symbols name -->
+<md-icon>search</md-icon>
+<md-icon>home</md-icon>
+<md-icon>settings</md-icon>
+
+<!-- Custom SVG icon -->
+<md-icon>
+  <svg viewBox="0 0 24 24">
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+  </svg>
+</md-icon>
+```

--- a/list/README.md
+++ b/list/README.md
@@ -1,0 +1,50 @@
+# List
+
+[Material Design 3 Lists](https://m3.material.io/components/lists/overview).
+
+Lists are continuous, vertical indexes of text and images.
+
+## Import
+
+```js
+import 'material/list/list.js'
+import 'material/list/list-item.js'
+```
+
+## Usage
+
+```html
+<md-list>
+  <!-- Basic item -->
+  <md-list-item type="button">
+    <div slot="headline">One-line item</div>
+  </md-list-item>
+
+  <!-- Item with leading icon -->
+  <md-list-item type="button">
+    <md-icon slot="start">star</md-icon>
+    <div slot="headline">Item with start icon</div>
+  </md-list-item>
+
+  <!-- Two-line item with avatar and trailing icon -->
+  <md-list-item type="button">
+    <img slot="start" src="./avatar.png" alt="Avatar" style="width: 40px; height: 40px; border-radius: 50%;" />
+    <div slot="headline">Two-line item</div>
+    <div slot="supporting-text">Supporting text goes here</div>
+    <md-icon slot="end">more_vert</md-icon>
+  </md-list-item>
+
+  <!-- Link item -->
+  <md-list-item type="link" href="https://example.com" target="_blank">
+    <md-icon slot="start">link</md-icon>
+    <div slot="headline">Link item</div>
+    <md-icon slot="end">open_in_new</md-icon>
+  </md-list-item>
+
+  <!-- Disabled item -->
+  <md-list-item disabled>
+    <md-icon slot="start">block</md-icon>
+    <div slot="headline">Disabled item</div>
+  </md-list-item>
+</md-list>
+```

--- a/radio/README.md
+++ b/radio/README.md
@@ -1,0 +1,22 @@
+# Radio
+
+[Material Design 3 Radio button](https://m3.material.io/components/radio-button/overview).
+
+Radio buttons allow users to select one option from a set.
+
+## Import
+
+```js
+import 'material/radio/radio.js'
+```
+
+## Usage
+
+```html
+<md-radio name="group" value="1" checked></md-radio>
+<md-radio name="group" value="2"></md-radio>
+<md-radio name="group" value="3"></md-radio>
+
+<!-- Disabled -->
+<md-radio name="group" value="4" disabled></md-radio>
+```

--- a/search/README.md
+++ b/search/README.md
@@ -1,0 +1,28 @@
+# Search
+
+Material 3 search component built with `<md-text-field>` and `<md-icon>`.
+
+## Import
+
+```js
+import 'material/search/search.js'
+```
+
+## Usage
+
+```html
+<md-search label="Search" placeholder="Search..."></md-search>
+```
+
+### Properties and Attributes
+
+| Property      | Attribute     | Type     | Default    | Description                     |
+| ------------- | ------------- | -------- | ---------- | ------------------------------- |
+| `label`       | `label`       | `string` | `'Search'` | The label for the search input. |
+| `placeholder` | `placeholder` | `string` | `'Search'` | Placeholder text for the input. |
+| `value`       | `value`       | `string` | `''`       | Current search value.           |
+
+### Slots
+
+- `leading-icon`: Element placed at start (defaults to `<md-icon>search</md-icon>`).
+- `trailing-icon`: Element placed at end when a value is present (defaults to a clear button with `<md-icon>close</md-icon>`).

--- a/tooltip/README.md
+++ b/tooltip/README.md
@@ -1,0 +1,34 @@
+# Tooltip
+
+[Material Design 3 Tooltip](https://m3.material.io/components/tooltips/overview).
+
+Tooltips display informative text when users hover over, focus on, or tap an element.
+
+## Import
+
+```js
+import 'material/tooltip/tooltip.js'
+```
+
+## Usage
+
+### Plain Tooltip
+
+```html
+<md-tooltip text="This is a plain tooltip">
+  <md-button>Hover me</md-button>
+</md-tooltip>
+```
+
+### Rich Tooltip
+
+```html
+<md-tooltip type="rich">
+  <md-button>Hover me</md-button>
+  <div slot="headline">Headline</div>
+  <div slot="text">Rich tooltip provides additional context and can include actions.</div>
+  <div slot="actions">
+    <md-button color="text" size="extra-small">Action</md-button>
+  </div>
+</md-tooltip>
+```


### PR DESCRIPTION
## Description

- Replaces the jsDelivr hits badge with the new jsDelivr package badge.
- Removes the outdated line stating that all upstream documentation still applies.
- Adds a list of all components linking directly to their respective README files under the Documentation section.
- Adds usage README files for components that previously lacked one (`badge`, `checkbox`, `icon`, `list`, `radio`, `search`, `tooltip`) so all links resolve properly.