### PR TITLE
fix(pickers): fix pickers readme and demos

### DIFF
--- a/demo/date-picker-demo.html
+++ b/demo/date-picker-demo.html
@@ -13,12 +13,11 @@
       onload="this.onload=null;this.rel='stylesheet'" />
     <link
       rel="preload"
-      href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght@400;500;700&&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght@400;500;700&display=swap"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'" />
 
     <link rel="icon" href="./images/material.jpeg" />
-
     <link rel="stylesheet" href="./css/styles.css" />
 
     <script type="importmap">
@@ -36,32 +35,103 @@
         }
       }
     </script>
-    <script type="module" src="/pickers/date-picker.js"></script>
-    <script type="module" src="/pickers/datetime-picker-dialog.js"></script>
-    <script type="module" src="/buttons/button.js"></script>
-    <script type="module" src="/text/text-field.js"></script>
+    <script type="module">
+      import 'material/pickers/date-picker.js'
+      import 'material/pickers/datetime-picker-dialog.js'
+      import 'material/buttons/button.js'
+      import 'material/text/text-field.js'
+      import 'material/icon/icon.js'
+    </script>
+
+    <style>
+      body {
+        background: var(--md-sys-color-background, #fef7ff);
+        color: var(--md-sys-color-on-background, #1d1b20);
+        padding: 24px;
+        max-width: 800px;
+        margin: 0 auto;
+        box-sizing: border-box;
+      }
+
+      .header-nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      .demo-section {
+        margin-bottom: 32px;
+        background: var(--md-sys-color-surface-container, #f3edf7);
+        border-radius: 24px;
+        padding: 24px;
+        box-sizing: border-box;
+      }
+
+      .demo-section h2 {
+        margin-top: 0;
+        margin-bottom: 16px;
+        font-size: 1.25rem;
+        font-weight: 500;
+      }
+
+      .value-display {
+        margin-top: 16px;
+        font-weight: 500;
+        color: var(--md-sys-color-primary, #6750a4);
+      }
+    </style>
   </head>
   <body>
+    <div class="header-nav">
+      <a href="./index.html" style="display: inline-flex; align-items: center; gap: 4px">
+        <md-icon style="font-size: 18px">arrow_back</md-icon> Back to Material 3 Demo
+      </a>
+      <a href="./time-picker-demo.html" style="display: inline-flex; align-items: center; gap: 4px">
+        Time Picker Demo <md-icon style="font-size: 18px">arrow_forward</md-icon>
+      </a>
+    </div>
+
+    <h1>Date Picker Demo</h1>
+
     <div class="demo-section">
       <h2>Embedded Date Picker</h2>
       <md-date-picker id="embedded-picker"></md-date-picker>
-      <p>Selected Value: <span id="embedded-value">None</span></p>
+      <p class="value-display">Selected Value: <span id="embedded-value">None</span></p>
     </div>
 
     <div class="demo-section">
       <h2>Date Picker Dialog</h2>
       <md-button id="dialog-trigger" color="filled">Open Date Picker</md-button>
       <md-datetime-picker-dialog id="dialog-picker" type="date"></md-datetime-picker-dialog>
-      <p>Dialog Value: <span id="dialog-value">None</span></p>
+      <p class="value-display">Dialog Value: <span id="dialog-value">None</span></p>
     </div>
 
     <div class="demo-section">
       <h2>Text Field with Date Picker</h2>
-      <md-text-field id="date-field" label="Birthday" type="date"></md-text-field>
-      <!-- Picker is now internal to text-field -->
+      <p style="margin-top: 0; color: var(--md-sys-color-on-surface-variant)">
+        Click the calendar icon to open the picker dialog:
+      </p>
+      <md-text-field id="date-field" label="Birthday" type="date" style="max-width: 320px"></md-text-field>
+      <p class="value-display">Field Value: <span id="date-field-value">None</span></p>
     </div>
 
-    <script>
+    <div class="demo-section">
+      <h2>Text Field with Date &amp; Time Picker</h2>
+      <p style="margin-top: 0; color: var(--md-sys-color-on-surface-variant)">
+        Supports <code>type="datetime-local"</code> for selecting both date and time:
+      </p>
+      <md-text-field
+        id="datetime-field"
+        label="Appointment"
+        type="datetime-local"
+        style="max-width: 320px"></md-text-field>
+      <p class="value-display">Datetime Value: <span id="datetime-field-value">None</span></p>
+    </div>
+
+    <script type="module">
       const embeddedPicker = document.getElementById('embedded-picker')
       const embeddedValue = document.getElementById('embedded-value')
       embeddedPicker.addEventListener('change', (e) => {
@@ -76,14 +146,20 @@
         dialogPicker.show()
       })
 
-      dialogPicker.addEventListener('confirm', (e) => {
-        dialogValue.textContent = dialogPicker.value
+      dialogPicker.addEventListener('confirm', () => {
+        dialogValue.textContent = dialogPicker.value || 'None'
       })
 
       const dateField = document.getElementById('date-field')
-
+      const dateFieldValue = document.getElementById('date-field-value')
       dateField.addEventListener('change', () => {
-        console.log('data changed', dateField.value)
+        dateFieldValue.textContent = dateField.value || 'None'
+      })
+
+      const datetimeField = document.getElementById('datetime-field')
+      const datetimeFieldValue = document.getElementById('datetime-field-value')
+      datetimeField.addEventListener('change', () => {
+        datetimeFieldValue.textContent = datetimeField.value || 'None'
       })
     </script>
   </body>

--- a/demo/date-picker-demo.html
+++ b/demo/date-picker-demo.html
@@ -134,8 +134,8 @@
     <script type="module">
       const embeddedPicker = document.getElementById('embedded-picker')
       const embeddedValue = document.getElementById('embedded-value')
-      embeddedPicker.addEventListener('change', (e) => {
-        embeddedValue.textContent = e.target.value
+      embeddedPicker.addEventListener('change', () => {
+        embeddedValue.textContent = embeddedPicker.value || 'None'
       })
 
       const dialogTrigger = document.getElementById('dialog-trigger')

--- a/demo/index.html
+++ b/demo/index.html
@@ -160,6 +160,8 @@
               <ul>
                 <li><a href="./list-demo.html">List Demo</a></li>
                 <li><a href="./carousel-demo.html">Carousel Demo</a></li>
+                <li><a href="./date-picker-demo.html">Date Picker Demo</a></li>
+                <li><a href="./time-picker-demo.html">Time Picker Demo</a></li>
               </ul>
             </div>
 

--- a/demo/time-picker-demo.html
+++ b/demo/time-picker-demo.html
@@ -18,7 +18,6 @@
       onload="this.onload=null;this.rel='stylesheet'" />
 
     <link rel="icon" href="./images/material.jpeg" />
-
     <link rel="stylesheet" href="./css/styles.css" />
 
     <script type="importmap">
@@ -36,36 +35,104 @@
         }
       }
     </script>
-    <script type="module" src="../pickers/time-picker.js"></script>
-    <script type="module" src="../pickers/datetime-picker-dialog.js"></script>
-    <script type="module" src="../buttons/button.js"></script>
+    <script type="module">
+      import 'material/pickers/time-picker.js'
+      import 'material/pickers/datetime-picker-dialog.js'
+      import 'material/buttons/button.js'
+      import 'material/text/text-field.js'
+      import 'material/icon/icon.js'
+    </script>
+
+    <style>
+      body {
+        background: var(--md-sys-color-background, #fef7ff);
+        color: var(--md-sys-color-on-background, #1d1b20);
+        padding: 24px;
+        max-width: 800px;
+        margin: 0 auto;
+        box-sizing: border-box;
+      }
+
+      .header-nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      .demo-section {
+        margin-bottom: 32px;
+        background: var(--md-sys-color-surface-container, #f3edf7);
+        border-radius: 24px;
+        padding: 24px;
+        box-sizing: border-box;
+      }
+
+      .demo-section h2 {
+        margin-top: 0;
+        margin-bottom: 16px;
+        font-size: 1.25rem;
+        font-weight: 500;
+      }
+
+      .value-display {
+        margin-top: 16px;
+        font-weight: 500;
+        color: var(--md-sys-color-primary, #6750a4);
+      }
+    </style>
   </head>
   <body>
+    <div class="header-nav">
+      <a href="./index.html" style="display: inline-flex; align-items: center; gap: 4px">
+        <md-icon style="font-size: 18px">arrow_back</md-icon> Back to Material 3 Demo
+      </a>
+      <a href="./date-picker-demo.html" style="display: inline-flex; align-items: center; gap: 4px">
+        Date Picker Demo <md-icon style="font-size: 18px">arrow_forward</md-icon>
+      </a>
+    </div>
+
+    <h1>Time Picker Demo</h1>
+
     <div class="demo-section">
       <h2>Embedded Time Picker</h2>
       <md-time-picker id="embedded-picker"></md-time-picker>
-      <p>Selected Value: <span id="embedded-value">None</span></p>
+      <p class="value-display">Selected Value: <span id="embedded-value">None</span></p>
     </div>
 
     <div class="demo-section">
       <h2>Time Picker Dialog</h2>
       <md-button id="dialog-trigger" color="filled">Open Time Picker</md-button>
       <md-datetime-picker-dialog id="dialog-picker" type="time"></md-datetime-picker-dialog>
-      <p>Dialog Value: <span id="dialog-value">None</span></p>
+      <p class="value-display">Dialog Value: <span id="dialog-value">None</span></p>
     </div>
 
-    <script>
-      // Embedded
+    <div class="demo-section">
+      <h2>Text Field with Time Picker</h2>
+      <p style="margin-top: 0; color: var(--md-sys-color-on-surface-variant)">
+        Click the clock icon to open the picker dialog:
+      </p>
+      <md-text-field id="time-field" label="Meeting Time" type="time" style="max-width: 320px"></md-text-field>
+      <p class="value-display">Field Value: <span id="time-field-value">None</span></p>
+    </div>
+
+    <div class="demo-section">
+      <h2>Combined Date &amp; Time Picker Dialog</h2>
+      <md-button id="dt-dialog-trigger" color="filled">Open Date &amp; Time Picker</md-button>
+      <md-datetime-picker-dialog id="dt-dialog-picker" type="datetime-local"></md-datetime-picker-dialog>
+      <p class="value-display">Datetime Value: <span id="dt-dialog-value">None</span></p>
+    </div>
+
+    <script type="module">
       const embeddedPicker = document.getElementById('embedded-picker')
       const embeddedValue = document.getElementById('embedded-value')
-
-      embeddedValue.textContent = embeddedPicker.value
 
       embeddedPicker.addEventListener('change', (e) => {
         embeddedValue.textContent = e.target.value
       })
 
-      // Dialog
       const dialogTrigger = document.getElementById('dialog-trigger')
       const dialogPicker = document.getElementById('dialog-picker')
       const dialogValue = document.getElementById('dialog-value')
@@ -74,8 +141,26 @@
         dialogPicker.show()
       })
 
-      dialogPicker.addEventListener('confirm', (e) => {
-        dialogValue.textContent = dialogPicker.value
+      dialogPicker.addEventListener('confirm', () => {
+        dialogValue.textContent = dialogPicker.value || 'None'
+      })
+
+      const timeField = document.getElementById('time-field')
+      const timeFieldValue = document.getElementById('time-field-value')
+      timeField.addEventListener('change', () => {
+        timeFieldValue.textContent = timeField.value || 'None'
+      })
+
+      const dtDialogTrigger = document.getElementById('dt-dialog-trigger')
+      const dtDialogPicker = document.getElementById('dt-dialog-picker')
+      const dtDialogValue = document.getElementById('dt-dialog-value')
+
+      dtDialogTrigger.addEventListener('click', () => {
+        dtDialogPicker.show()
+      })
+
+      dtDialogPicker.addEventListener('confirm', () => {
+        dtDialogValue.textContent = dtDialogPicker.value || 'None'
       })
     </script>
   </body>

--- a/pickers/README.md
+++ b/pickers/README.md
@@ -1,9 +1,211 @@
 # Date & Time Pickers
 
-WIP
+[Material 3 Date Pickers](https://m3.material.io/components/date-pickers/overview) and [Material 3 Time Pickers](https://m3.material.io/components/time-pickers/overview).
+
+Date and time pickers let users select dates, times, or date-time combinations via interactive calendar views, clock dials, modal dialogs, or integrated text fields.
+
+## Import
+
+```js
+// Individual components
+import 'material/pickers/date-picker.js'
+import 'material/pickers/time-picker.js'
+import 'material/pickers/datetime-picker-dialog.js'
+
+// Or use via text-field (automatically includes the datetime picker dialog)
+import 'material/text/text-field.js'
+```
+
+## Usage
+
+### Embedded Date Picker
+
+Use `<md-date-picker>` for an inline calendar view:
+
+```html
+<md-date-picker id="date-picker" value="2026-09-15"></md-date-picker>
+
+<script>
+  const picker = document.getElementById('date-picker')
+  picker.addEventListener('change', (e) => {
+    console.log('Selected date:', e.target.value) // YYYY-MM-DD
+  })
+</script>
+```
+
+To hide the top headline/subhead header:
+
+```html
+<md-date-picker hide-header></md-date-picker>
+```
+
+### Date Picker Dialog
+
+Use `<md-datetime-picker-dialog type="date">` to present a modal date selection dialog:
+
+```html
+<md-button id="open-btn" color="filled">Select Date</md-button>
+<md-datetime-picker-dialog id="date-dialog" type="date"></md-datetime-picker-dialog>
+
+<script>
+  const btn = document.getElementById('open-btn')
+  const dialog = document.getElementById('date-dialog')
+
+  btn.addEventListener('click', () => {
+    dialog.show()
+  })
+
+  dialog.addEventListener('confirm', () => {
+    console.log('Confirmed date:', dialog.value)
+  })
+</script>
+```
+
+### Embedded Time Picker
+
+Use `<md-time-picker>` for an interactive analog clock dial with hour and minute selection:
+
+```html
+<md-time-picker id="time-picker" value="14:30" format="12"></md-time-picker>
+
+<script>
+  const picker = document.getElementById('time-picker')
+  picker.addEventListener('change', (e) => {
+    console.log('Selected time:', e.target.value) // HH:MM (24h format)
+  })
+</script>
+```
+
+### Time Picker Dialog
+
+Use `<md-datetime-picker-dialog type="time">` for a modal time selection dialog:
+
+```html
+<md-button id="open-time-btn" color="filled">Select Time</md-button>
+<md-datetime-picker-dialog id="time-dialog" type="time"></md-datetime-picker-dialog>
+
+<script>
+  const btn = document.getElementById('open-time-btn')
+  const dialog = document.getElementById('time-dialog')
+
+  btn.addEventListener('click', () => {
+    dialog.show()
+  })
+
+  dialog.addEventListener('confirm', () => {
+    console.log('Confirmed time:', dialog.value)
+  })
+</script>
+```
+
+### Combined Date & Time Picker Dialog
+
+Use `<md-datetime-picker-dialog type="datetime-local">` to allow selecting both date and time in a single dialog:
+
+```html
+<md-button id="open-dt-btn" color="filled">Select Date & Time</md-button>
+<md-datetime-picker-dialog id="dt-dialog" type="datetime-local"></md-datetime-picker-dialog>
+
+<script>
+  const btn = document.getElementById('open-dt-btn')
+  const dialog = document.getElementById('dt-dialog')
+
+  btn.addEventListener('click', () => {
+    dialog.show()
+  })
+
+  dialog.addEventListener('confirm', () => {
+    console.log('Confirmed datetime:', dialog.value) // YYYY-MM-DDTHH:MM
+  })
+</script>
+```
+
+### Pickers via Text Field
+
+`<md-text-field>` has built-in integration with picker dialogs. Setting `type="date"`, `type="time"`, or `type="datetime-local"` automatically adds the appropriate interactive icon button (calendar or clock) that opens the picker dialog and updates the field's value on confirmation:
+
+```html
+<!-- Date input with calendar picker -->
+<md-text-field label="Birthday" type="date" color="outlined"></md-text-field>
+
+<!-- Time input with clock picker -->
+<md-text-field label="Meeting Time" type="time" color="outlined"></md-text-field>
+
+<!-- Date and time input with combined picker -->
+<md-text-field label="Appointment" type="datetime-local" color="outlined"></md-text-field>
+```
+
+## API Reference
+
+### `<md-date-picker>`
+
+#### Properties & Attributes
+
+| Property     | Attribute     | Type      | Default     | Description                                               |
+| ------------ | ------------- | --------- | ----------- | --------------------------------------------------------- |
+| `value`      | `value`       | `string`  | `''`        | Selected date in `YYYY-MM-DD` format.                     |
+| `min`        | `min`         | `string`  | `undefined` | Earliest selectable date (`YYYY-MM-DD`).                  |
+| `max`        | `max`         | `string`  | `undefined` | Latest selectable date (`YYYY-MM-DD`).                    |
+| `hideHeader` | `hide-header` | `boolean` | `false`     | When true, hides the top title and selected date display. |
+
+#### Events
+
+| Event    | Description                                                  |
+| -------- | ------------------------------------------------------------ |
+| `change` | Dispatched when a date is selected. Bubbles and is composed. |
+| `input`  | Dispatched on user interaction with the date selection.      |
+
+---
+
+### `<md-time-picker>`
+
+#### Properties & Attributes
+
+| Property | Attribute | Type     | Default   | Description                                |
+| -------- | --------- | -------- | --------- | ------------------------------------------ |
+| `value`  | `value`   | `string` | `'00:00'` | Selected time in 24-hour `HH:MM` format.   |
+| `format` | `format`  | `number` | `12`      | Time format display: `12` (AM/PM) or `24`. |
+
+#### Events
+
+| Event    | Description                                               |
+| -------- | --------------------------------------------------------- |
+| `change` | Dispatched when time is updated. Bubbles and is composed. |
+| `input`  | Dispatched as the clock dial is dragged or clicked.       |
+
+---
+
+### `<md-datetime-picker-dialog>`
+
+#### Properties & Attributes
+
+| Property | Attribute | Type      | Default  | Description                                                   |
+| -------- | --------- | --------- | -------- | ------------------------------------------------------------- |
+| `open`   | `open`    | `boolean` | `false`  | Whether the dialog is open.                                   |
+| `type`   | `type`    | `string`  | `'date'` | Picker type: `'date'`, `'time'`, or `'datetime-local'`.       |
+| `value`  | `value`   | `string`  | `''`     | Current value (`YYYY-MM-DD`, `HH:MM`, or `YYYY-MM-DDTHH:MM`). |
+| `min`    | `min`     | `string`  | `''`     | Minimum date constraint.                                      |
+| `max`    | `max`     | `string`  | `''`     | Maximum date constraint.                                      |
+| `format` | `format`  | `number`  | `12`     | Time format (`12` or `24`) for time view.                     |
+
+#### Methods
+
+| Method    | Parameters | Description        |
+| --------- | ---------- | ------------------ |
+| `show()`  | None       | Opens the dialog.  |
+| `close()` | None       | Closes the dialog. |
+
+#### Events
+
+| Event     | Description                                                                   |
+| --------- | ----------------------------------------------------------------------------- |
+| `confirm` | Dispatched when the user clicks OK. The confirmed value is on `dialog.value`. |
+| `cancel`  | Dispatched when the user clicks Cancel.                                       |
+| `close`   | Dispatched when the dialog is closed.                                         |
+| `change`  | Dispatched when the confirmed value updates.                                  |
 
 ## Demos
 
-- [Date picker](https://material-esm.github.io/material/demo/date-picker-demo.html)
-- [Time picker](https://material-esm.github.io/material/demo/time-picker-demo.html)
-- [Pickers via text fields](https://material-esm.github.io/material/demo/)
+- [Date Picker Demo](https://material-esm.github.io/material/demo/date-picker-demo.html)
+- [Time Picker Demo](https://material-esm.github.io/material/demo/time-picker-demo.html)
+- [Material 3 Main Demo (Text Field Pickers)](https://material-esm.github.io/material/demo/)

--- a/pickers/date-picker.js
+++ b/pickers/date-picker.js
@@ -196,8 +196,8 @@ export class DatePicker extends LitElement {
   selectDate(date) {
     if (this.isDateDisabled(date)) return
     this.value = this.formatDate(date)
-    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
     this.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
   }
 
   selectYear(year) {

--- a/pickers/date-picker.js
+++ b/pickers/date-picker.js
@@ -12,7 +12,7 @@ export class DatePicker extends LitElement {
     open: { type: Boolean, reflect: true },
     displayDate: { state: true }, // Date object
     view: { state: true }, // 'day' | 'year' | 'month'
-    hideHeader: { type: Boolean, attribute: 'hide-header' }
+    hideHeader: { type: Boolean, attribute: 'hide-header' },
   }
 
   constructor() {
@@ -44,9 +44,7 @@ export class DatePicker extends LitElement {
   render() {
     return html`
       <div class="container">
-        ${this.hideHeader ? nothing : this.renderHeader()}
-        ${this.renderContent()}
-        ${this.renderActions()}
+        ${this.hideHeader ? nothing : this.renderHeader()} ${this.renderContent()} ${this.renderActions()}
       </div>
     `
   }
@@ -61,12 +59,13 @@ export class DatePicker extends LitElement {
     const selectedDate = this.value ? new Date(this.value) : null
     // Adjust for timezone offset to display correctly
     if (selectedDate) {
-        selectedDate.setMinutes(selectedDate.getMinutes() + selectedDate.getTimezoneOffset())
+      selectedDate.setMinutes(selectedDate.getMinutes() + selectedDate.getTimezoneOffset())
     }
 
-    const dateString = selectedDate && !isNaN(selectedDate.getTime())
-      ? new Intl.DateTimeFormat('en-US', { weekday: 'short', month: 'short', day: 'numeric' }).format(selectedDate)
-      : 'Select date'
+    const dateString =
+      selectedDate && !isNaN(selectedDate.getTime())
+        ? new Intl.DateTimeFormat('en-US', { weekday: 'short', month: 'short', day: 'numeric' }).format(selectedDate)
+        : 'Select date'
 
     return html`
       <div class="header">
@@ -79,8 +78,7 @@ export class DatePicker extends LitElement {
   renderContent() {
     return html`
       <div class="content">
-        ${this.renderControls()}
-        ${this.view === 'day' ? this.renderCalendar() : this.renderYearList()}
+        ${this.renderControls()} ${this.view === 'day' ? this.renderCalendar() : this.renderYearList()}
       </div>
     `
   }
@@ -136,26 +134,18 @@ export class DatePicker extends LitElement {
         day: true,
         selected: isSelected,
         today: isToday,
-        disabled: isDisabled
+        disabled: isDisabled,
       }
 
-      days.push(html`
-        <div class=${classMap(classes)} @click=${() => !isDisabled && this.selectDate(date)}>
-          ${i}
-        </div>
-      `)
+      days.push(html` <div class=${classMap(classes)} @click=${() => !isDisabled && this.selectDate(date)}>${i}</div> `)
     }
 
     const weekdays = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
     return html`
       <div class="calendar">
-        <div class="weekdays">
-          ${weekdays.map(d => html`<div class="weekday">${d}</div>`)}
-        </div>
-        <div class="days">
-          ${days}
-        </div>
+        <div class="weekdays">${weekdays.map((d) => html`<div class="weekday">${d}</div>`)}</div>
+        <div class="days">${days}</div>
       </div>
     `
   }
@@ -168,12 +158,10 @@ export class DatePicker extends LitElement {
     const endYear = currentYear + 100
 
     for (let y = startYear; y <= endYear; y++) {
-        const isSelected = this._displayDate.getFullYear() === y
-        years.push(html`
-            <div class="year ${isSelected ? 'selected' : ''}" @click=${() => this.selectYear(y)}>
-                ${y}
-            </div>
-        `)
+      const isSelected = this._displayDate.getFullYear() === y
+      years.push(html`
+        <div class="year ${isSelected ? 'selected' : ''}" @click=${() => this.selectYear(y)}>${y}</div>
+      `)
     }
 
     // We should scroll to the selected year.
@@ -183,9 +171,9 @@ export class DatePicker extends LitElement {
 
   renderActions() {
     return html`
-        <div class="actions">
-            <slot name="actions"></slot>
-        </div>
+      <div class="actions">
+        <slot name="actions"></slot>
+      </div>
     `
   }
 
@@ -208,8 +196,8 @@ export class DatePicker extends LitElement {
   selectDate(date) {
     if (this.isDateDisabled(date)) return
     this.value = this.formatDate(date)
-    this.dispatchEvent(new Event('change', { bubbles: true }))
-    this.dispatchEvent(new Event('input', { bubbles: true }))
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
+    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
   }
 
   selectYear(year) {
@@ -228,9 +216,11 @@ export class DatePicker extends LitElement {
 
   isToday(date) {
     const today = new Date()
-    return date.getDate() === today.getDate() &&
+    return (
+      date.getDate() === today.getDate() &&
       date.getMonth() === today.getMonth() &&
       date.getFullYear() === today.getFullYear()
+    )
   }
 
   isDateDisabled(date) {
@@ -261,7 +251,7 @@ export class DatePicker extends LitElement {
     }
 
     .subhead {
-      font-size: 12px; // label-medium
+      font-size: 12px; /* label-medium */
       line-height: 16px;
       letter-spacing: 0.5px;
       font-weight: 500;
@@ -269,7 +259,7 @@ export class DatePicker extends LitElement {
     }
 
     .headline {
-      font-size: 32px; // headline-large
+      font-size: 32px; /* headline-large */
       line-height: 40px;
       color: var(--md-sys-color-on-surface);
       margin-top: 4px;
@@ -288,27 +278,27 @@ export class DatePicker extends LitElement {
     }
 
     .period-selector {
-        display: flex;
-        align-items: center;
-        cursor: pointer;
-        padding: 8px;
-        border-radius: 24px; // Full
-        font-weight: 500;
-        font-size: 14px; // label-large
-        color: var(--md-sys-color-on-surface-variant);
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      padding: 8px;
+      border-radius: 24px; /* Full */
+      font-weight: 500;
+      font-size: 14px; /* label-large */
+      color: var(--md-sys-color-on-surface-variant);
     }
 
     .period-selector:hover {
-        background-color: var(--md-sys-color-surface-variant); // slightly darker
+      background-color: var(--md-sys-color-surface-variant); /* slightly darker */
     }
 
     .dropdown-icon {
-        font-size: 18px;
-        margin-left: 4px;
+      font-size: 18px;
+      margin-left: 4px;
     }
 
     .arrows {
-        display: flex;
+      display: flex;
     }
 
     .calendar {
@@ -376,38 +366,38 @@ export class DatePicker extends LitElement {
     }
 
     .day.selected:hover {
-        background-color: var(--md-sys-color-primary); /* Keep it primary on hover if selected */
+      background-color: var(--md-sys-color-primary); /* Keep it primary on hover if selected */
     }
 
     .year-list {
-        height: 250px;
-        overflow-y: auto;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+      height: 250px;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
     }
 
     .year {
-        padding: 12px 24px;
-        cursor: pointer;
-        border-radius: 16px;
-        font-size: 16px;
+      padding: 12px 24px;
+      cursor: pointer;
+      border-radius: 16px;
+      font-size: 16px;
     }
 
     .year:hover {
-        background-color: var(--md-sys-color-surface-variant);
+      background-color: var(--md-sys-color-surface-variant);
     }
 
     .year.selected {
-        background-color: var(--md-sys-color-primary);
-        color: var(--md-sys-color-on-primary);
+      background-color: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
     }
 
     .actions {
-        display: flex;
-        justify-content: flex-end;
-        padding: 8px 12px;
-        gap: 8px;
+      display: flex;
+      justify-content: flex-end;
+      padding: 8px 12px;
+      gap: 8px;
     }
   `
 }

--- a/pickers/datetime-picker-dialog.js
+++ b/pickers/datetime-picker-dialog.js
@@ -134,14 +134,18 @@ export class DateTimePickerDialog extends LitElement {
       const pickerDate = this._date || this.renderRoot.querySelector('md-date-picker')?.value || ''
       const pickerTime = this._time || this.renderRoot.querySelector('md-time-picker')?.value || '00:00'
       if (!pickerDate) return // Date is mandatory
+      this._date = pickerDate
+      this._time = pickerTime
       this.value = `${pickerDate}T${pickerTime}`
     } else if (this.type === 'date') {
       const pickerDate = this._date || this.renderRoot.querySelector('md-date-picker')?.value || ''
       if (pickerDate) {
+        this._date = pickerDate
         this.value = pickerDate
       }
     } else if (this.type === 'time') {
       const pickerTime = this._time || this.renderRoot.querySelector('md-time-picker')?.value || '00:00'
+      this._time = pickerTime
       this.value = pickerTime
     }
 

--- a/pickers/datetime-picker-dialog.js
+++ b/pickers/datetime-picker-dialog.js
@@ -131,29 +131,33 @@ export class DateTimePickerDialog extends LitElement {
 
   confirm() {
     if (this.type === 'datetime-local') {
-      if (!this._date) return // Date is mandatory
-      if (!this._time) {
-        this._time = '00:00'
-      }
-      this.value = `${this._date}T${this._time}`
+      const pickerDate = this._date || this.renderRoot.querySelector('md-date-picker')?.value || ''
+      const pickerTime = this._time || this.renderRoot.querySelector('md-time-picker')?.value || '00:00'
+      if (!pickerDate) return // Date is mandatory
+      this.value = `${pickerDate}T${pickerTime}`
     } else if (this.type === 'date') {
-      // Value already updated
+      const pickerDate = this._date || this.renderRoot.querySelector('md-date-picker')?.value || ''
+      if (pickerDate) {
+        this.value = pickerDate
+      }
     } else if (this.type === 'time') {
-      // Value already updated
+      const pickerTime = this._time || this.renderRoot.querySelector('md-time-picker')?.value || '00:00'
+      this.value = pickerTime
     }
 
     this.open = false
-    this.dispatchEvent(new Event('confirm', { bubbles: true }))
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
+    this.dispatchEvent(new Event('confirm', { bubbles: true, composed: true }))
   }
 
   cancel() {
     this.open = false
-    this.dispatchEvent(new Event('cancel', { bubbles: true }))
+    this.dispatchEvent(new Event('cancel', { bubbles: true, composed: true }))
   }
 
   handleClose() {
     this.open = false
-    this.dispatchEvent(new Event('close', { bubbles: true }))
+    this.dispatchEvent(new Event('close', { bubbles: true, composed: true }))
   }
 
   show() {

--- a/pickers/datetime-picker-dialog.js
+++ b/pickers/datetime-picker-dialog.js
@@ -150,7 +150,7 @@ export class DateTimePickerDialog extends LitElement {
     }
 
     this.open = false
-    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
+    this.dispatchEvent(new Event('change', { bubbles: true }))
     this.dispatchEvent(new Event('confirm', { bubbles: true, composed: true }))
   }
 

--- a/pickers/time-picker.js
+++ b/pickers/time-picker.js
@@ -96,7 +96,8 @@ export class TimePicker extends LitElement {
         class="clock-face"
         @pointerdown=${this.handlePointerDown}
         @pointermove=${this.handlePointerMove}
-        @pointerup=${this.handlePointerUp}>
+        @pointerup=${this.handlePointerUp}
+        @pointercancel=${this.handlePointerUp}>
         <div class="center-dot"></div>
         <div class="hand" style="transform: rotate(${rotation}deg)">
           <div class="hand-line"></div>

--- a/pickers/time-picker.js
+++ b/pickers/time-picker.js
@@ -19,47 +19,41 @@ export class TimePicker extends LitElement {
 
   updated(changedProperties) {
     if (changedProperties.has('value') && this.value) {
-        this.syncFromValue()
+      this.syncFromValue()
     }
   }
 
   syncFromValue() {
-      if (!this.value) return
-      const [h, m] = this.value.split(':').map(Number)
-      if (isNaN(h) || isNaN(m)) return
+    if (!this.value) return
+    const [h, m] = this.value.split(':').map(Number)
+    if (isNaN(h) || isNaN(m)) return
 
-      if (this.format === 12) {
-          this.period = h >= 12 ? 'PM' : 'AM'
-          let hour12 = h % 12
-          if (hour12 === 0) hour12 = 12
-          // We don't store displayHour separately, we derive it or use a getter?
-          // But for editing, we might want state.
-          // Let's rely on internal state matching value for now, unless interaction changes it.
-      }
+    if (this.format === 12) {
+      this.period = h >= 12 ? 'PM' : 'AM'
+      let hour12 = h % 12
+      if (hour12 === 0) hour12 = 12
+      // We don't store displayHour separately, we derive it or use a getter?
+      // But for editing, we might want state.
+      // Let's rely on internal state matching value for now, unless interaction changes it.
+    }
   }
 
   get _parsedTime() {
-      if (!this.value) return { h: 0, m: 0 }
-      const [h, m] = this.value.split(':').map(Number)
-      return { h: isNaN(h) ? 0 : h, m: isNaN(m) ? 0 : m }
+    if (!this.value) return { h: 0, m: 0 }
+    const [h, m] = this.value.split(':').map(Number)
+    return { h: isNaN(h) ? 0 : h, m: isNaN(m) ? 0 : m }
   }
 
   render() {
-    return html`
-      <div class="container">
-        ${this.renderHeader()}
-        ${this.renderClock()}
-        ${this.renderActions()}
-      </div>
-    `
+    return html` <div class="container">${this.renderHeader()} ${this.renderClock()} ${this.renderActions()}</div> `
   }
 
   renderHeader() {
     const { h, m } = this._parsedTime
     let displayHour = h
     if (this.format === 12) {
-        displayHour = h % 12
-        if (displayHour === 0) displayHour = 12
+      displayHour = h % 12
+      if (displayHour === 0) displayHour = 12
     }
     const displayMinute = String(m).padStart(2, '0')
 
@@ -73,16 +67,20 @@ export class TimePicker extends LitElement {
     return html`
       <div class="header">
         <div class="time-display">
-            <span class="time-part ${classMap(hourClasses)}" @click=${() => this.view = 'hour'}>${displayHour}</span>
-            <span class="separator">:</span>
-            <span class="time-part ${classMap(minuteClasses)}" @click=${() => this.view = 'minute'}>${displayMinute}</span>
+          <span class="time-part ${classMap(hourClasses)}" @click=${() => (this.view = 'hour')}>${displayHour}</span>
+          <span class="separator">:</span>
+          <span class="time-part ${classMap(minuteClasses)}" @click=${() => (this.view = 'minute')}
+            >${displayMinute}</span
+          >
         </div>
-        ${this.format === 12 ? html`
-            <div class="period-selector">
+        ${this.format === 12
+          ? html`
+              <div class="period-selector">
                 <div class="period ${amActive ? 'active' : ''}" @click=${() => this.setPeriod('AM')}>AM</div>
                 <div class="period ${pmActive ? 'active' : ''}" @click=${() => this.setPeriod('PM')}>PM</div>
-            </div>
-        ` : nothing}
+              </div>
+            `
+          : nothing}
       </div>
     `
   }
@@ -94,170 +92,180 @@ export class TimePicker extends LitElement {
     const rotation = this.getHandRotation()
 
     return html`
-      <div class="clock-face" @pointerdown=${this.handlePointerDown} @pointermove=${this.handlePointerMove} @pointerup=${this.handlePointerUp}>
+      <div
+        class="clock-face"
+        @pointerdown=${this.handlePointerDown}
+        @pointermove=${this.handlePointerMove}
+        @pointerup=${this.handlePointerUp}>
         <div class="center-dot"></div>
         <div class="hand" style="transform: rotate(${rotation}deg)">
-            <div class="hand-line"></div>
-            <div class="hand-circle"></div>
+          <div class="hand-line"></div>
+          <div class="hand-circle"></div>
         </div>
-        ${numbers.map(n => html`
-            <div class="number ${n.selected ? 'selected' : ''}" style="left: ${n.x}px; top: ${n.y}px">
-                ${n.label}
-            </div>
-        `)}
+        ${numbers.map(
+          (n) => html`
+            <div class="number ${n.selected ? 'selected' : ''}" style="left: ${n.x}px; top: ${n.y}px">${n.label}</div>
+          `,
+        )}
       </div>
     `
   }
 
   getHourNumbers() {
-      const { h } = this._parsedTime
-      const radius = 100 // clock radius is 128, numbers at ~100
-      const center = 128
-      const nums = []
+    const { h } = this._parsedTime
+    const radius = 100 // clock radius is 128, numbers at ~100
+    const center = 128
+    const nums = []
 
-      const is12 = this.format === 12
-      const count = is12 ? 12 : 12 // Simplified for 24h first ring for now, assume 12h first
+    const is12 = this.format === 12
+    const count = is12 ? 12 : 12 // Simplified for 24h first ring for now, assume 12h first
 
-      for (let i = 1; i <= 12; i++) {
-          const angle = (i * 30 - 90) * (Math.PI / 180)
-          const x = center + radius * Math.cos(angle)
-          const y = center + radius * Math.sin(angle)
+    for (let i = 1; i <= 12; i++) {
+      const angle = (i * 30 - 90) * (Math.PI / 180)
+      const x = center + radius * Math.cos(angle)
+      const y = center + radius * Math.sin(angle)
 
-          let val = i
-          if (val === 12 && !is12) val = 0 // for 24h? tricky.
-          // Let's focus on 12h format primarily as per spec example
+      let val = i
+      if (val === 12 && !is12) val = 0 // for 24h? tricky.
+      // Let's focus on 12h format primarily as per spec example
 
-          let selected = false
-          if (is12) {
-              let currentH12 = h % 12
-              if (currentH12 === 0) currentH12 = 12
-              if (currentH12 === i) selected = true
-          }
-
-          nums.push({ label: i, x, y, selected })
+      let selected = false
+      if (is12) {
+        let currentH12 = h % 12
+        if (currentH12 === 0) currentH12 = 12
+        if (currentH12 === i) selected = true
       }
-      return nums
+
+      nums.push({ label: i, x, y, selected })
+    }
+    return nums
   }
 
   getMinuteNumbers() {
-      const { m } = this._parsedTime
-      const radius = 100
-      const center = 128
-      const nums = []
+    const { m } = this._parsedTime
+    const radius = 100
+    const center = 128
+    const nums = []
 
-      for (let i = 0; i < 12; i++) {
-          const val = i * 5
-          const angle = (i * 30 - 90) * (Math.PI / 180)
-          const x = center + radius * Math.cos(angle)
-          const y = center + radius * Math.sin(angle)
+    for (let i = 0; i < 12; i++) {
+      const val = i * 5
+      const angle = (i * 30 - 90) * (Math.PI / 180)
+      const x = center + radius * Math.cos(angle)
+      const y = center + radius * Math.sin(angle)
 
-          // Only show numbers for multiples of 5
-          const selected = m === val
-          nums.push({ label: String(val).padStart(2, '0'), x, y, selected })
-      }
-      return nums
+      // Only show numbers for multiples of 5
+      const selected = m === val
+      nums.push({ label: String(val).padStart(2, '0'), x, y, selected })
+    }
+    return nums
   }
 
   getHandRotation() {
-      const { h, m } = this._parsedTime
-      if (this.view === 'hour') {
-          // 12 hours = 360 deg, 1 hour = 30 deg
-          let val = h % 12
-          // if (val === 0) val = 12; // 12 should be at top (0 deg visual, but 270 math).
-          // 12 -> 0 deg (top). 3 -> 90 deg.
-          // (val * 30) gives 12->360->0, 3->90.
-          return val * 30
-      } else {
-          // 60 minutes = 360 deg, 1 min = 6 deg
-          return m * 6
-      }
+    const { h, m } = this._parsedTime
+    if (this.view === 'hour') {
+      // 12 hours = 360 deg, 1 hour = 30 deg
+      let val = h % 12
+      // if (val === 0) val = 12; // 12 should be at top (0 deg visual, but 270 math).
+      // 12 -> 0 deg (top). 3 -> 90 deg.
+      // (val * 30) gives 12->360->0, 3->90.
+      return val * 30
+    } else {
+      // 60 minutes = 360 deg, 1 min = 6 deg
+      return m * 6
+    }
   }
 
   renderActions() {
     return html`
-        <div class="actions">
-            <slot name="actions"></slot>
-        </div>
+      <div class="actions">
+        <slot name="actions"></slot>
+      </div>
     `
   }
 
   setPeriod(p) {
-      if (this.period === p) return
-      this.period = p
-      // Update value
-      let { h, m } = this._parsedTime
-      if (p === 'AM' && h >= 12) {
-          h -= 12
-      } else if (p === 'PM' && h < 12) {
-          h += 12
-      }
-      this.updateValue(h, m)
+    if (this.period === p) return
+    this.period = p
+    // Update value
+    let { h, m } = this._parsedTime
+    if (p === 'AM' && h >= 12) {
+      h -= 12
+    } else if (p === 'PM' && h < 12) {
+      h += 12
+    }
+    this.updateValue(h, m)
   }
 
   updateValue(h, m) {
-      const time = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
-      this.value = time
-      this.dispatchEvent(new Event('input', { bubbles: true }))
-      this.dispatchEvent(new Event('change', { bubbles: true }))
+    const time = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+    this.value = time
+    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
   }
 
   handlePointerDown(e) {
-      this._isDragging = true
-      this.setClockTimeFromEvent(e)
+    this._isDragging = true
+    try {
+      e.currentTarget?.setPointerCapture?.(e.pointerId)
+    } catch (_) {}
+    this.setClockTimeFromEvent(e)
   }
 
   handlePointerMove(e) {
-      if (!this._isDragging) return
-      e.preventDefault() // prevent scroll
-      this.setClockTimeFromEvent(e)
+    if (!this._isDragging) return
+    e.preventDefault() // prevent scroll
+    this.setClockTimeFromEvent(e)
   }
 
   handlePointerUp(e) {
+    if (this._isDragging) {
+      try {
+        e.currentTarget?.releasePointerCapture?.(e.pointerId)
+      } catch (_) {}
       this._isDragging = false
       if (this.view === 'hour') {
-          // Switch to minute view on mouse up (common behavior)
-          // But maybe wait a bit or animate?
-          this.view = 'minute'
+        this.view = 'minute'
       }
+    }
   }
 
   setClockTimeFromEvent(e) {
-      const rect = this.shadowRoot.querySelector('.clock-face').getBoundingClientRect()
-      const centerX = rect.width / 2
-      const centerY = rect.height / 2
-      const x = e.clientX - rect.left - centerX
-      const y = e.clientY - rect.top - centerY
+    const rect = this.shadowRoot.querySelector('.clock-face').getBoundingClientRect()
+    const centerX = rect.width / 2
+    const centerY = rect.height / 2
+    const x = e.clientX - rect.left - centerX
+    const y = e.clientY - rect.top - centerY
 
-      // Calculate angle
-      // atan2(y, x) returns -PI to PI.
-      // 0 is right (3 o'clock).
-      // We want 0 at top (12 o'clock).
-      // top: x=0, y=-1. atan2(-1, 0) = -PI/2.
+    // Calculate angle
+    // atan2(y, x) returns -PI to PI.
+    // 0 is right (3 o'clock).
+    // We want 0 at top (12 o'clock).
+    // top: x=0, y=-1. atan2(-1, 0) = -PI/2.
 
-      let angle = Math.atan2(y, x) * (180 / Math.PI) + 90
-      if (angle < 0) angle += 360
+    let angle = Math.atan2(y, x) * (180 / Math.PI) + 90
+    if (angle < 0) angle += 360
 
-      // angle is now 0 at top, increasing clockwise.
+    // angle is now 0 at top, increasing clockwise.
 
-      if (this.view === 'hour') {
-          // 360 deg / 12 = 30 deg per hour
-          let hour = Math.round(angle / 30)
-          if (hour === 0) hour = 12
+    if (this.view === 'hour') {
+      // 360 deg / 12 = 30 deg per hour
+      let hour = Math.round(angle / 30)
+      if (hour === 0) hour = 12
 
-          // Handle AM/PM logic for internal 24h storage
-          if (this.period === 'PM' && hour !== 12) hour += 12
-          if (this.period === 'AM' && hour === 12) hour = 0
+      // Handle AM/PM logic for internal 24h storage
+      if (this.period === 'PM' && hour !== 12) hour += 12
+      if (this.period === 'AM' && hour === 12) hour = 0
 
-          const { m } = this._parsedTime
-          this.updateValue(hour, m)
-      } else {
-          // 360 deg / 60 = 6 deg per minute
-          let minute = Math.round(angle / 6)
-          if (minute === 60) minute = 0
+      const { m } = this._parsedTime
+      this.updateValue(hour, m)
+    } else {
+      // 360 deg / 60 = 6 deg per minute
+      let minute = Math.round(angle / 6)
+      if (minute === 60) minute = 0
 
-          const { h } = this._parsedTime
-          this.updateValue(h, minute)
-      }
+      const { h } = this._parsedTime
+      this.updateValue(h, minute)
+    }
   }
 
   static styles = css`
@@ -306,7 +314,7 @@ export class TimePicker extends LitElement {
     }
 
     .separator {
-        margin: 0 4px;
+      margin: 0 4px;
     }
 
     .period-selector {
@@ -325,7 +333,7 @@ export class TimePicker extends LitElement {
     }
 
     .period:hover {
-        background-color: var(--md-sys-color-surface-variant);
+      background-color: var(--md-sys-color-surface-variant);
     }
 
     .period.active {
@@ -372,46 +380,46 @@ export class TimePicker extends LitElement {
     }
 
     .hand-line {
-        width: 2px;
-        height: 100%;
-        background-color: var(--md-sys-color-primary, #6750a4);
-        margin: 0 auto;
+      width: 2px;
+      height: 100%;
+      background-color: var(--md-sys-color-primary, #6750a4);
+      margin: 0 auto;
     }
 
     .hand-circle {
-        width: 48px;
-        height: 48px;
-        border-radius: 50%;
-        background-color: var(--md-sys-color-primary, #6750a4);
-        position: absolute;
-        top: -24px; /* Center circle at tip */
-        left: 50%;
-        transform: translateX(-50%);
-        opacity: 0.8; /* See number through it? M3 usually solid but behind text. */
-        /* Actually in M3, the selected number is white text on primary circle. */
-        /* The hand circle is the background for the selected number. */
-        z-index: 1;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background-color: var(--md-sys-color-primary, #6750a4);
+      position: absolute;
+      top: -24px; /* Center circle at tip */
+      left: 50%;
+      transform: translateX(-50%);
+      opacity: 0.8; /* See number through it? M3 usually solid but behind text. */
+      /* Actually in M3, the selected number is white text on primary circle. */
+      /* The hand circle is the background for the selected number. */
+      z-index: 1;
     }
 
     .number {
-        position: absolute;
-        width: 48px;
-        height: 48px;
-        line-height: 48px;
-        text-align: center;
-        transform: translate(-50%, -50%);
-        font-size: 16px;
-        color: var(--md-sys-color-on-surface);
-        pointer-events: none;
-        z-index: 3; /* Above hand circle */
+      position: absolute;
+      width: 48px;
+      height: 48px;
+      line-height: 48px;
+      text-align: center;
+      transform: translate(-50%, -50%);
+      font-size: 16px;
+      color: var(--md-sys-color-on-surface);
+      pointer-events: none;
+      z-index: 3; /* Above hand circle */
     }
 
     .number.selected {
-        color: var(--md-sys-color-on-primary, #ffffff);
+      color: var(--md-sys-color-on-primary, #ffffff);
     }
 
     .actions {
-        display: none; /* Embedded doesn't enforce actions, dialog does */
+      display: none; /* Embedded doesn't enforce actions, dialog does */
     }
   `
 }


### PR DESCRIPTION
## Summary

Fixes the pickers README documentation and resolves broken picker demo pages.

- **`pickers/README.md`**: Replaced the "WIP" placeholder with comprehensive Material 3 documentation, including design spec links, imports (individual components & text field integration), detailed usage examples, and full API reference tables.
- **`demo/date-picker-demo.html`**: Fixed 404 imports when deployed to GitHub Pages/subpaths (caused by leading slashes), modernized container and typography styling with Material 3 design tokens, added navigation links, and added datetime-local demo.
- **`demo/time-picker-demo.html`**: Standardized imports via import map, fixed premature value access before custom elements upgraded, updated styling, and added text field and datetime-local dialog demos.
- **`demo/index.html`**: Added Date Picker and Time Picker demo links to the "Other demo pages" list.
- **`pickers/datetime-picker-dialog.js`**: Ensured `confirm()` captures current picker value when confirmed without edits, and added `composed: true` to events.
- **`pickers/date-picker.js` & `pickers/time-picker.js`**: Cleaned up CSS comments, added pointer capture for clock dial dragging, and made events composed.

## Verification

- Automated browser tests using Playwright verified that both demo pages load without console errors or 404s.
- Tested embedded selection, dialog open/confirm, and text field calendar/clock integrations across all components.